### PR TITLE
fix: colors not working on Windows

### DIFF
--- a/Versionize.Tests/ProgramTests.cs
+++ b/Versionize.Tests/ProgramTests.cs
@@ -1,4 +1,4 @@
-using Shouldly;
+﻿using Shouldly;
 using Versionize.CommandLine;
 using Versionize.Tests.TestSupport;
 using Xunit;
@@ -25,7 +25,7 @@ public class ProgramTests : IDisposable
         var exitCode = Program.Main(new[] { "--workingDir", _testSetup.WorkingDirectory, "--dry-run", "--skip-dirty" });
 
         exitCode.ShouldBe(0);
-        _testPlatformAbstractions.Formmatters.ShouldContain(formatter => formatter.Any(f => "bumping version from 1.1.0 to 1.1.0 in projects".Equals(f.Target)));
+        _testPlatformAbstractions.Formatters.ShouldContain(formatter => formatter.Any(f => "bumping version from 1.1.0 to 1.1.0 in projects".Equals(f.Target)));
     }
 
     [Fact]
@@ -34,7 +34,7 @@ public class ProgramTests : IDisposable
         var exitCode = Program.Main(new[] { "--workingDir", _testSetup.WorkingDirectory, "--dry-run", "--skip-dirty", "--release-as", "2.0.0" });
 
         exitCode.ShouldBe(0);
-        _testPlatformAbstractions.Formmatters.ShouldContain(formatter => formatter.Any(f => "bumping version from 1.1.0 to 2.0.0 in projects".Equals(f.Target)));
+        _testPlatformAbstractions.Formatters.ShouldContain(formatter => formatter.Any(f => "bumping version from 1.1.0 to 2.0.0 in projects".Equals(f.Target)));
     }
 
     [Fact]

--- a/Versionize.Tests/TestSupport/TestPlatformAbstractions.cs
+++ b/Versionize.Tests/TestSupport/TestPlatformAbstractions.cs
@@ -1,5 +1,4 @@
 ﻿using System.Drawing;
-using Colorful;
 using Versionize.CommandLine;
 
 namespace Versionize.Tests.TestSupport;
@@ -9,7 +8,7 @@ public class TestPlatformAbstractions : IPlatformAbstractions
     public LogLevel Verbosity { get; set; }
     public List<FormatterMessage> Messages { get; } = new List<FormatterMessage>();
 
-    public IEnumerable<Formatter[]> Formmatters
+    public IEnumerable<Formatter[]> Formatters
     {
         get
         {
@@ -22,12 +21,12 @@ public class TestPlatformAbstractions : IPlatformAbstractions
         throw new CommandLineExitException(exitCode);
     }
 
-    public void WriteLine(string message, Color color)
+    public void WriteLine(string message, ConsoleColor color)
     {
         Messages.Add(new FormatterMessage { Message = message });
     }
 
-    public void WriteLineFormatted(string message, Color color, Formatter[] formatters)
+    public void WriteLineFormatted(string message, ConsoleColor color, Formatter[] formatters)
     {
         Messages.Add(new FormatterMessage { Message = message, Formatters = formatters });
     }

--- a/Versionize/CommandLine/CommandLineUI.cs
+++ b/Versionize/CommandLine/CommandLineUI.cs
@@ -1,5 +1,4 @@
 ﻿using System.Drawing;
-using Colorful;
 
 namespace Versionize.CommandLine;
 
@@ -9,7 +8,7 @@ public static class CommandLineUI
 
     public static int Exit(string message, int code)
     {
-        Platform.WriteLine(message, Color.Red);
+        Platform.WriteLine(message, ConsoleColor.Red);
         Platform.Exit(code);
 
         return code;
@@ -17,18 +16,26 @@ public static class CommandLineUI
 
     public static void Information(string message)
     {
-        Platform.WriteLine(message, Color.LightGray);
+        Platform.WriteLine(message, ConsoleColor.Gray);
     }
 
     public static void Step(string message)
     {
         var messageFormatters = new Formatter[]
         {
-            new Formatter("√", Color.Green),
-            new Formatter(message, Color.LightGray),
+            new Formatter("√", ConsoleColor.Green),
+            new Formatter(message, ConsoleColor.Gray),
         };
 
-        Platform.WriteLineFormatted("{0} {1}", Color.White, messageFormatters);
+
+        Platform.WriteLineFormatted("{0} {1}", ConsoleColor.White, messageFormatters);
+    }
+
+    public static void DryRun(string message)
+    {
+        Platform.WriteLine("\n---", ConsoleColor.Gray);
+        Platform.WriteLine(message, ConsoleColor.DarkGray);
+        Platform.WriteLine("---\n", ConsoleColor.Gray);
     }
 
     public static LogLevel Verbosity { get => Platform.Verbosity; set => Platform.Verbosity = value; }

--- a/Versionize/CommandLine/IPlatformAbstractions.cs
+++ b/Versionize/CommandLine/IPlatformAbstractions.cs
@@ -1,13 +1,12 @@
 ﻿using System.Drawing;
-using Colorful;
 
 namespace Versionize.CommandLine;
 
 public interface IPlatformAbstractions
 {
     void Exit(int exitCode);
-    void WriteLine(string message, Color color);
-    void WriteLineFormatted(string message, Color color, Formatter[] messageFormatters);
+    void WriteLine(string message, ConsoleColor color);
+    void WriteLineFormatted(string message, ConsoleColor color, Formatter[] messageFormatters);
 
     LogLevel Verbosity { get; set; }
 }

--- a/Versionize/CommandLine/PlatformAbstractions.cs
+++ b/Versionize/CommandLine/PlatformAbstractions.cs
@@ -1,8 +1,4 @@
-using System.Drawing;
-using Colorful;
-using Console = Colorful.Console;
-
-namespace Versionize.CommandLine;
+﻿namespace Versionize.CommandLine;
 
 public class PlatformAbstractions : IPlatformAbstractions
 {
@@ -13,23 +9,78 @@ public class PlatformAbstractions : IPlatformAbstractions
         Environment.Exit(exitCode);
     }
 
-    public void WriteLine(string message, Color color)
+    public void WriteLine(string message, ConsoleColor color)
     {
         if (Verbosity == LogLevel.Silent)
         {
             return;
         }
 
-        Console.WriteLine(message, color);
+        WriteInColor(Console.WriteLine, message, color);
     }
 
-    public void WriteLineFormatted(string message, Color color, Formatter[] messageFormatters)
+    public void WriteLineFormatted(string message, ConsoleColor color, Formatter[] messageFormatters)
     {
         if (Verbosity == LogLevel.Silent)
         {
             return;
         }
 
-        Console.WriteLineFormatted(message, color, messageFormatters);
+        var buffer = message.ToCharArray();
+        int startIndex = 0;
+        for (int i = 0; i < messageFormatters.Length; ++i)
+        {
+            var replacementText = messageFormatters[i].Target;
+            var replacementColor = messageFormatters[i].Color;
+            var replacementIndex = message.IndexOf($"{{{i}}}", startIndex);
+
+            if (replacementIndex == -1)
+            {
+                throw new InvalidOperationException($"{{{i}}} is not present in the formatted message: {message}.");
+            }
+            if (replacementIndex > 0)
+            {
+                // Write non-formatted text (up until the formatted part begins).
+                var count = replacementIndex - startIndex;
+                WriteInColor(Console.Write, buffer, startIndex, count, color);
+            }
+
+            // Write formatted text.
+            WriteInColor(Console.Write, replacementText, replacementColor);
+            int digits = i < 10 ? 1 : (int)Math.Floor(Math.Log10(i) + 1);
+            startIndex = replacementIndex + 2 + digits;
+        }
+
+        // Write remaining non-formatted text.
+        var remainingCount = message.Length - startIndex;
+        WriteInColor(Console.WriteLine, buffer, startIndex, remainingCount, color);
     }
+
+    private static void WriteInColor<T>(Action<T> action, T target, ConsoleColor color)
+    {
+        var oldColor = System.Console.ForegroundColor;
+        System.Console.ForegroundColor = color;
+        action.Invoke(target);
+        System.Console.ForegroundColor = oldColor;
+    }
+
+    private static void WriteInColor(Action<char[], int, int> action, char[] buffer, int index, int count, ConsoleColor color)
+    {
+        var oldColor = System.Console.ForegroundColor;
+        System.Console.ForegroundColor = color;
+        action.Invoke(buffer, index, count);
+        System.Console.ForegroundColor = oldColor;
+    }
+}
+
+public class Formatter
+{
+    public Formatter(string target, ConsoleColor color)
+    {
+        Target = target;
+        Color = color;
+    }
+
+    public string Target { get; set; }
+    public ConsoleColor Color { get; set; }
 }

--- a/Versionize/Versionize.csproj
+++ b/Versionize/Versionize.csproj
@@ -23,7 +23,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Colorful.Console" Version="1.2.15" />
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0175" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.0" />
     <PackageReference Include="NuGet.Versioning" Version="6.0.0" />

--- a/Versionize/WorkingCopy.cs
+++ b/Versionize/WorkingCopy.cs
@@ -131,9 +131,7 @@ public class WorkingCopy
             if (options.DryRun)
             {
                 string markdown = ChangelogBuilder.GenerateMarkdown(nextVersion, versionTime, changelogLinkBuilder, conventionalCommits, options.Changelog);
-                Information("\n---");
-                Information(markdown.TrimEnd('\n'));
-                Information("---\n");
+                DryRun(markdown.TrimEnd('\n'));
             }
             else
             {


### PR DESCRIPTION
Replace Colorful.Console with custom helper methods.

![Screenshot 2022-02-19 110314](https://user-images.githubusercontent.com/6819362/154782053-ac77f9f5-276d-423a-b8d0-24d966d6f30c.jpg)

Which OS do you use? Would you see how these colors look on your machine?

I've tested different scenarios manually but haven't written any tests yet. If you'd rather go with Spectre, that's completely fine with me. Regardless, it was kind of interesting implementing a custom formatted writer.

I also ran benchmarks and discovered that Colorful.Console isn't built in Release config

![Screenshot 2022-02-19 101604](https://user-images.githubusercontent.com/6819362/154782039-51b54475-c5d2-4a33-a5a8-547b389e5b0c.jpg)

And the benchmark results:

|            Method |     Mean |   Error |  StdDev |  Gen 0 | Allocated |
|------------------ |---------:|--------:|--------:|-------:|----------:|
| ColorfulFormatted | 307.1 µs | 5.95 µs | 7.74 µs | 1.4648 |  12,027 B |
|   CustomFormatted | 378.8 µs | 3.54 µs | 3.13 µs |      - |     496 B |

```csharp
const string Message = "BEFORE | {0} | IN THE MIDDLE | {1} | AFTER";
const string BaseMessage = "Hello, world.";
private static readonly Formatter[] CustomFormatters = new []
{
    new Formatter("√", ConsoleColor.Green),
    new Formatter(BaseMessage, ConsoleColor.Gray),
};
```

Fixes #46

