### PR TITLE
feat: add support for aggregating prereleases in changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Options:
   --changelog-all                      Include all commits in the changelog not just fix, feat and breaking changes
   --commit-suffix                      Suffix to be added to the end of the release commit message (e.g. [skip ci])
   -p|--pre-release                     Release as pre-release version with given pre release label.
+  -a|--aggregate-pre-releases          Include all pre-release commits in the changelog since the last full version.
 
 Commands:
   inspect                              Prints the current version to stdout
@@ -167,6 +168,44 @@ The following workflow illustrates how pre-release workflows with versionize wor
 > versionize
 // Generates version v2.0.0
 ```
+
+### Aggregated pre-releases changelog
+
+By default, each commit message only appears in the release it was introduced. When using the pre-release feature
+this can result in a fragmented changelog. For example, when promoting to a full release the user has to browse
+through all the pre-release sections to see what's included.
+
+```
+v1.0.0-alpha.0
+- featA
+v1.0.0-alpha.1
+- featB
+v1.0.0
+```
+
+So to get around that you can pass the `--aggregate-pre-releases` flag
+
+```
+versionize --pre-release alpha
+versionize --pre-release alpha
+versionize --aggregate-pre-releases
+```
+
+to get output like the following
+
+```
+v1.0.0-alpha.0
+- featA
+v1.0.0-alpha.1
+- featB
+v1.0.0
+- featA
+- featB
+```
+
+This also works together with the `pre-release` option
+
+versionize --pre-release alpha --aggregate-pre-releases
 
 ## Configuration
 

--- a/Versionize/Program.cs
+++ b/Versionize/Program.cs
@@ -33,7 +33,7 @@ public static class Program
         var optionIncludeAllCommitsInChangelog = app.Option("--changelog-all", "Include all commits in the changelog not just fix, feat and breaking changes", CommandOptionType.NoValue);
         var optionCommitSuffix = app.Option("--commit-suffix", "Suffix to be added to the end of the release commit message (e.g. [skip ci])", CommandOptionType.SingleValue);
         var optionPrerelease = app.Option("-p|--pre-release", "Release as pre-release version with given pre release label.", CommandOptionType.SingleValue);
-        var optionAggregatePrereleases = app.Option("-a|--aggregate-pre-releases", "Include all pre-release commits in each release.", CommandOptionType.NoValue);
+        var optionAggregatePrereleases = app.Option("-a|--aggregate-pre-releases", "Include all pre-release commits in the changelog since the last full version.", CommandOptionType.NoValue);
 
         var inspectCmd = app.Command("inspect", inspectCmd => inspectCmd.OnExecute(() =>
         {

--- a/Versionize/Program.cs
+++ b/Versionize/Program.cs
@@ -33,6 +33,7 @@ public static class Program
         var optionIncludeAllCommitsInChangelog = app.Option("--changelog-all", "Include all commits in the changelog not just fix, feat and breaking changes", CommandOptionType.NoValue);
         var optionCommitSuffix = app.Option("--commit-suffix", "Suffix to be added to the end of the release commit message (e.g. [skip ci])", CommandOptionType.SingleValue);
         var optionPrerelease = app.Option("-p|--pre-release", "Release as pre-release version with given pre release label.", CommandOptionType.SingleValue);
+        var optionAggregatePrereleases = app.Option("-a|--aggregate-pre-releases", "Include all pre-release commits in each release.", CommandOptionType.NoValue);
 
         var inspectCmd = app.Command("inspect", inspectCmd => inspectCmd.OnExecute(() =>
         {
@@ -62,6 +63,7 @@ public static class Program
                 CommitSuffix = optionCommitSuffix.Value(),
                 Prerelease = optionPrerelease.Value(),
                 Changelog = ChangelogOptions.Default,
+                AggregatePrereleases = optionAggregatePrereleases.HasValue(),
             },
             optionIncludeAllCommitsInChangelog.HasValue());
 
@@ -140,6 +142,7 @@ Exception detail:
             CommitSuffix = configuration.CommitSuffix ?? optionalConfiguration?.CommitSuffix,
             Prerelease = configuration.Prerelease ?? optionalConfiguration?.Prerelease,
             Changelog = changelog,
+            AggregatePrereleases = configuration.AggregatePrereleases,
         };
     }
 

--- a/Versionize/VersionizeOptions.cs
+++ b/Versionize/VersionizeOptions.cs
@@ -11,4 +11,5 @@ public class VersionizeOptions
     public String CommitSuffix { get; set; }
     public string Prerelease { get; set; }
     public ChangelogOptions Changelog { get; set; } = ChangelogOptions.Default;
+    public bool AggregatePrereleases { get; set; }
 }


### PR DESCRIPTION
resolves #74 

Still need to add tests and update the README but seems to work pretty well when trying out dummy version bumps on the Versionize repository locally.
