### PR TITLE
fix: moved bump statement up before csproj are altered Issue #78 

### DIFF
--- a/Versionize.Tests/WorkingCopyTests.cs
+++ b/Versionize.Tests/WorkingCopyTests.cs
@@ -443,6 +443,25 @@ public class WorkingCopyTests : IDisposable
         Assert.Equal(sb.Build(), changelogContents);
     }
 
+    [Fact]
+    public void ShouldDisplayExpectedMessage_BumpingVersionFromXToY()
+    {
+        TempProject.CreateCsharpProject(_testSetup.WorkingDirectory, "1.0.0");
+        var workingCopy = WorkingCopy.Discover(_testSetup.WorkingDirectory);
+
+        var fileCommitter = new FileCommitter(_testSetup);
+
+        // Release an initial version
+        fileCommitter.CommitChange("feat: initial commit");
+        workingCopy.Versionize(new VersionizeOptions());
+
+        // Patch release
+        fileCommitter.CommitChange("fix: a fix");
+        workingCopy.Versionize(new VersionizeOptions());
+
+        _testPlatformAbstractions.Messages.ShouldContain("√ bumping version from 1.0.0 to 1.0.1 in projects");
+    }
+
     private IEnumerable<string> VersionTagNames
     {
         get { return _testSetup.Repository.Tags.Select(t => t.FriendlyName); }

--- a/Versionize/WorkingCopy.cs
+++ b/Versionize/WorkingCopy.cs
@@ -136,6 +136,9 @@ public class WorkingCopy
 
         var versionTime = DateTimeOffset.Now;
 
+
+        Step($"bumping version from {projects.Version} to {nextVersion} in projects");
+       
         // Commit changelog and version source
         if (!options.DryRun && (nextVersion != projects.Version))
         {
@@ -146,8 +149,6 @@ public class WorkingCopy
                 Commands.Stage(repo, projectFile);
             }
         }
-
-        Step($"bumping version from {projects.Version} to {nextVersion} in projects");
 
         var changelog = ChangelogBuilder.CreateForPath(workingDirectory);
         var changelogLinkBuilder = LinkBuilderFactory.CreateFor(repo);


### PR DESCRIPTION
simple fix to Issue #78 

Note: for some Reason the `projects.version` property is changed by `WriteVersion` altough the projects objects are not reloaded, therefore I am not sure if this is sufficient or if there is an underlying issue 