### PR TITLE
feat: Add first-parent commits option

### DIFF
--- a/Versionize.Tests/WorkingCopyTests.cs
+++ b/Versionize.Tests/WorkingCopyTests.cs
@@ -402,7 +402,7 @@ public partial class WorkingCopyTests : IDisposable
 
         // Release an initial version
         fileCommitter.CommitChange("feat: initial commit");
-        workingCopy.Versionize(new VersionizeOptions() { FirstParentOnlyCommit = true });
+        workingCopy.Versionize(new VersionizeOptions { FirstParentOnlyCommit = true });
 
         var featBranch = _testSetup.Repository.CreateBranch("feature/new-feature");
         Commands.Checkout(_testSetup.Repository, featBranch);
@@ -414,15 +414,15 @@ public partial class WorkingCopyTests : IDisposable
 
         var author = GetAuthorSignature();
         Commands.Checkout(_testSetup.Repository, _testSetup.Repository.Branches["master"]);
-        workingCopy.Versionize(new VersionizeOptions() { FirstParentOnlyCommit = true });
-        workingCopy.Versionize(new VersionizeOptions() { FirstParentOnlyCommit = true });
-        _testSetup.Repository.Merge(featBranch, author, new MergeOptions()
+        workingCopy.Versionize(new VersionizeOptions { FirstParentOnlyCommit = true });
+        workingCopy.Versionize(new VersionizeOptions { FirstParentOnlyCommit = true });
+        _testSetup.Repository.Merge(featBranch, author, new MergeOptions
         {
             CommitOnSuccess = true,
         });
 
         fileCommitter.CommitChange("feat: new feature on file");
-        workingCopy.Versionize(new VersionizeOptions() { FirstParentOnlyCommit = true });
+        workingCopy.Versionize(new VersionizeOptions { FirstParentOnlyCommit = true });
 
         var versionTagNames = VersionTagNames.ToList();
         versionTagNames.ShouldBe(new[] { "v1.0.0", "v1.0.1", "v1.0.2", "v1.1.0" });

--- a/Versionize/Config/CliConfig.cs
+++ b/Versionize/Config/CliConfig.cs
@@ -22,6 +22,10 @@ public sealed class CliConfig
     public CommandOption ConfigurationDirectory { get; init; }
     public CommandOption ProjectName { get; init; }
     public CommandOption UseCommitMessageInsteadOfTagToFindLastReleaseCommit { get; init; }
+    /// <summary>
+    /// The first parent only options allows you to ignore commits that are not the first parent.
+    /// </summary>
+    public CommandOption FirstParentOnlyCommit { get; init; }
 
     public static CliConfig Create(CommandLineApplication app)
     {
@@ -110,6 +114,11 @@ public sealed class CliConfig
             UseCommitMessageInsteadOfTagToFindLastReleaseCommit = app.Option(
                 "--find-release-commit-via-message",
                 "Use commit message instead of tag to find last release commit",
+                CommandOptionType.NoValue),
+
+            FirstParentOnlyCommit = app.Option(
+                "--first-parent-commits",
+                "The first parent only options allows you to ignore commits that are not the first parent.",
                 CommandOptionType.NoValue),
         };
     }

--- a/Versionize/Config/ConfigProvider.cs
+++ b/Versionize/Config/ConfigProvider.cs
@@ -84,6 +84,7 @@ public static class ConfigProvider
             CommitParser = commit,
             Project = project,
             UseCommitMessageInsteadOfTagToFindLastReleaseCommit = cliConfig.UseCommitMessageInsteadOfTagToFindLastReleaseCommit.HasValue(),
+            FirstParentOnlyCommit = MergeBool(cliConfig.FirstParentOnlyCommit.HasValue(), fileConfig?.FirstParentOnlyCommit),
         };
     }
 

--- a/Versionize/Config/FileConfig.cs
+++ b/Versionize/Config/FileConfig.cs
@@ -12,10 +12,14 @@ public sealed class FileConfig
     public bool? TagOnly { get; set; }
     public bool? IgnoreInsignificantCommits { get; set; }
     public bool? ExitInsignificantCommits { get; set; }
+    /// <summary>
+    /// The first parent only options allows you to ignore commits that are not the first parent.
+    /// </summary>
+    public bool? FirstParentOnlyCommit { get; set; }
     public string CommitSuffix { get; set; }
     public string Prerelease { get; set; }
     public bool? AggregatePrereleases { get; set; }
-    
+
     public CommitParserOptions CommitParser { get; set; }
     public ProjectOptions[] Projects { get; set; } = [];
     public ChangelogOptions Changelog { get; set; }

--- a/Versionize/Config/VersionizeOptions.cs
+++ b/Versionize/Config/VersionizeOptions.cs
@@ -1,4 +1,4 @@
-﻿﻿namespace Versionize.Config;
+﻿namespace Versionize.Config;
 
 public sealed class VersionizeOptions
 {
@@ -14,7 +14,7 @@ public sealed class VersionizeOptions
     public string CommitSuffix { get; set; }
     public string Prerelease { get; set; }
     public bool AggregatePrereleases { get; set; }
-    
+
     public string WorkingDirectory { get; set; }
     public CommitParserOptions CommitParser { get; set; } = CommitParserOptions.Default;
     public ProjectOptions Project { get; set; } = ProjectOptions.DefaultOneProjectPerRepo;
@@ -28,4 +28,9 @@ public sealed class VersionizeOptions
     /// commit of the last release is to look for the last commit that contains a release message.
     /// </remarks>
     public bool UseCommitMessageInsteadOfTagToFindLastReleaseCommit { get; set; }
+
+    /// <summary>
+    /// The first parent only options allows you to ignore commits that are not the first parent.
+    /// </summary>
+    public bool FirstParentOnlyCommit { get; set; }
 }

--- a/Versionize/Git/RepositoryExtensions.cs
+++ b/Versionize/Git/RepositoryExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using LibGit2Sharp;
 using NuGet.Versioning;
-using Versionize.BumpFiles;
 using Versionize.Config;
 
 namespace Versionize.Git;
@@ -57,35 +56,31 @@ public static class RepositoryExtensions
         }
     }
 
-    public static List<Commit> GetCommitsSinceLastVersion(this Repository repository, Tag versionTag, ProjectOptions project)
+    public static List<Commit> GetCommitsSinceLastVersion(this Repository repository, Tag versionTag, ProjectOptions project, CommitFilter filter = null)
     {
         if (versionTag == null)
         {
-            return repository.GetCommits(project).ToList();
+            return repository.GetCommits(project, filter).ToList();
         }
 
-        var filter = new CommitFilter
-        {
-            ExcludeReachableFrom = versionTag
-        };
+        filter ??= new CommitFilter();
+        filter.ExcludeReachableFrom = versionTag;
 
         return repository.GetCommits(project, filter).ToList();
     }
 
-    public static List<Commit> GetCommitsSinceLastReleaseCommit(this Repository repository, ProjectOptions project)
+    public static List<Commit> GetCommitsSinceLastReleaseCommit(this Repository repository, ProjectOptions project, CommitFilter filter = null)
     {
         var lastReleaseCommit = repository
-            .GetCommits(project)
+            .GetCommits(project, filter)
             .FirstOrDefault(x => x.Message.StartsWith("chore(release):"));
         if (lastReleaseCommit == null)
         {
             return repository.Commits.ToList();
         }
 
-        var filter = new CommitFilter
-        {
-            ExcludeReachableFrom = lastReleaseCommit
-        };
+        filter ??= new CommitFilter();
+        filter.ExcludeReachableFrom = lastReleaseCommit;
 
         return repository.GetCommits(project, filter).ToList();
     }
@@ -125,7 +120,7 @@ public sealed class VersionOptions
 {
     public bool TagOnly { get; init; }
     public ProjectOptions Project { get; init; }
-    
+
     public static implicit operator VersionOptions(VersionizeOptions versionizeOptions)
     {
         return new VersionOptions

--- a/Versionize/Lifecycle/ConventionalCommitProvider.cs
+++ b/Versionize/Lifecycle/ConventionalCommitProvider.cs
@@ -1,4 +1,4 @@
-using LibGit2Sharp;
+﻿using LibGit2Sharp;
 using NuGet.Versioning;
 using Versionize.Config;
 using Versionize.ConventionalCommits;
@@ -7,7 +7,7 @@ using Versionize.Git;
 namespace Versionize;
 
 public sealed class ConventionalCommitProvider
-{    
+{
     public static (bool, IReadOnlyList<ConventionalCommit>) GetCommits(Repository repo, Options options, SemanticVersion version)
     {
         var versionToUseForCommitDiff = version;
@@ -26,29 +26,35 @@ public sealed class ConventionalCommitProvider
 
         var isInitialRelease = false;
         List<Commit> commitsInVersion;
+        var commitFilter = new CommitFilter()
+        {
+            FirstParentOnly = options.FirstParentOnlyCommit
+        };
+
         if (options.UseCommitMessageInsteadOfTagToFindLastReleaseCommit)
         {
-            var lastReleaseCommit = repo.GetCommits(options.Project).FirstOrDefault(x => x.Message.StartsWith("chore(release):"));
+            var lastReleaseCommit = repo.GetCommits(options.Project, commitFilter).FirstOrDefault(x => x.Message.StartsWith("chore(release):"));
             isInitialRelease = lastReleaseCommit is null;
-            commitsInVersion = repo.GetCommitsSinceLastReleaseCommit(options.Project);
+            commitsInVersion = repo.GetCommitsSinceLastReleaseCommit(options.Project, commitFilter);
         }
         else
         {
             var versionTag = repo.SelectVersionTag(versionToUseForCommitDiff, options.Project);
             isInitialRelease = versionTag == null;
-            commitsInVersion = repo.GetCommitsSinceLastVersion(versionTag, options.Project);
+            commitsInVersion = repo.GetCommitsSinceLastVersion(versionTag, options.Project, commitFilter);
         }
 
         var conventionalCommits = ConventionalCommitParser.Parse(commitsInVersion, options.CommitParser);
 
         return (isInitialRelease, conventionalCommits);
     }
-    
+
     public sealed class Options
     {
         public ProjectOptions Project { get; init; }
         public bool AggregatePrereleases { get; init; }
         public bool UseCommitMessageInsteadOfTagToFindLastReleaseCommit { get; init; }
+        public bool FirstParentOnlyCommit { get; init; }
         public CommitParserOptions CommitParser { get; init; }
 
         public static implicit operator Options(VersionizeOptions versionizeOptions)
@@ -59,6 +65,7 @@ public sealed class ConventionalCommitProvider
                 CommitParser = versionizeOptions.CommitParser,
                 Project = versionizeOptions.Project,
                 UseCommitMessageInsteadOfTagToFindLastReleaseCommit = versionizeOptions.UseCommitMessageInsteadOfTagToFindLastReleaseCommit,
+                FirstParentOnlyCommit = versionizeOptions.FirstParentOnlyCommit,
             };
         }
     }

--- a/Versionize/Lifecycle/ConventionalCommitProvider.cs
+++ b/Versionize/Lifecycle/ConventionalCommitProvider.cs
@@ -26,7 +26,7 @@ public sealed class ConventionalCommitProvider
 
         var isInitialRelease = false;
         List<Commit> commitsInVersion;
-        var commitFilter = new CommitFilter()
+        var commitFilter = new CommitFilter
         {
             FirstParentOnly = options.FirstParentOnlyCommit
         };


### PR DESCRIPTION
- Add first-parent-commits options : The first parent only options allows you to ignore commits that are not the first parent.

See #139 

Work based on version 2 - See #135 