### PR TITLE
feat: modify "first parent only" option names to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Versionize
+# Versionize
 
 [![Coverage Status](https://coveralls.io/repos/versionize/versionize/badge.svg?branch=)](https://coveralls.io/r/versionize/versionize?branch=master)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
@@ -59,6 +59,7 @@ Options:
   --find-release-commit-via-message    Use commit message instead of tag to find last release commit.
   --tag-only                           Don't read/write the version from/to project files. Depend on version tags only.
   --proj-name                          Name of a project defined in the configuration file (for monorepos)
+  --first-parent-only-commits          Ignore commits beyond the first parent
 
 Commands:
   inspect                              Prints the current version to stdout

--- a/Versionize.Tests/WorkingCopyTests.cs
+++ b/Versionize.Tests/WorkingCopyTests.cs
@@ -402,8 +402,9 @@ public partial class WorkingCopyTests : IDisposable
 
         // Release an initial version
         fileCommitter.CommitChange("feat: initial commit");
-        workingCopy.Versionize(new VersionizeOptions { FirstParentOnlyCommit = true });
+        workingCopy.Versionize(new VersionizeOptions { FirstParentOnlyCommits = true });
 
+        var defaultBranch = _testSetup.Repository.Branches.First();
         var featBranch = _testSetup.Repository.CreateBranch("feature/new-feature");
         Commands.Checkout(_testSetup.Repository, featBranch);
 
@@ -413,16 +414,16 @@ public partial class WorkingCopyTests : IDisposable
         fileCommitter.CommitChange("feat: last add on branch");
 
         var author = GetAuthorSignature();
-        Commands.Checkout(_testSetup.Repository, _testSetup.Repository.Branches["master"]);
-        workingCopy.Versionize(new VersionizeOptions { FirstParentOnlyCommit = true });
-        workingCopy.Versionize(new VersionizeOptions { FirstParentOnlyCommit = true });
+        Commands.Checkout(_testSetup.Repository, defaultBranch);
+        workingCopy.Versionize(new VersionizeOptions { FirstParentOnlyCommits = true });
+        workingCopy.Versionize(new VersionizeOptions { FirstParentOnlyCommits = true });
         _testSetup.Repository.Merge(featBranch, author, new MergeOptions
         {
             CommitOnSuccess = true,
         });
 
         fileCommitter.CommitChange("feat: new feature on file");
-        workingCopy.Versionize(new VersionizeOptions { FirstParentOnlyCommit = true });
+        workingCopy.Versionize(new VersionizeOptions { FirstParentOnlyCommits = true });
 
         var versionTagNames = VersionTagNames.ToList();
         versionTagNames.ShouldBe(new[] { "v1.0.0", "v1.0.1", "v1.0.2", "v1.1.0" });

--- a/Versionize/Config/CliConfig.cs
+++ b/Versionize/Config/CliConfig.cs
@@ -17,15 +17,15 @@ public sealed class CliConfig
     public CommandOption CommitSuffix { get; init; }
     public CommandOption Prerelease { get; init; }
     public CommandOption AggregatePrereleases { get; init; }
+    /// <summary>
+    /// Ignore commits beyond the first parent.
+    /// </summary>
+    public CommandOption FirstParentOnlyCommits { get; init; }
 
     public CommandOption WorkingDirectory { get; init; }
     public CommandOption ConfigurationDirectory { get; init; }
     public CommandOption ProjectName { get; init; }
     public CommandOption UseCommitMessageInsteadOfTagToFindLastReleaseCommit { get; init; }
-    /// <summary>
-    /// The first parent only options allows you to ignore commits that are not the first parent.
-    /// </summary>
-    public CommandOption FirstParentOnlyCommit { get; init; }
 
     public static CliConfig Create(CommandLineApplication app)
     {
@@ -106,6 +106,11 @@ public sealed class CliConfig
                 "Include all pre-release commits in the changelog since the last full version.",
                 CommandOptionType.NoValue),
 
+            FirstParentOnlyCommits = app.Option(
+                "--first-parent-only-commits",
+                "Ignore commits beyond the first parent.",
+                CommandOptionType.NoValue),
+
             ProjectName = app.Option(
                 "--proj-name",
                 "Name of a project defined in the configuration file (for monorepos)",
@@ -114,11 +119,6 @@ public sealed class CliConfig
             UseCommitMessageInsteadOfTagToFindLastReleaseCommit = app.Option(
                 "--find-release-commit-via-message",
                 "Use commit message instead of tag to find last release commit",
-                CommandOptionType.NoValue),
-
-            FirstParentOnlyCommit = app.Option(
-                "--first-parent-commits",
-                "The first parent only options allows you to ignore commits that are not the first parent.",
                 CommandOptionType.NoValue),
         };
     }

--- a/Versionize/Config/ConfigProvider.cs
+++ b/Versionize/Config/ConfigProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Versionize.CommandLine;
 
 namespace Versionize.Config;
@@ -81,10 +81,10 @@ public static class ConfigProvider
             CommitSuffix = cliConfig.CommitSuffix.Value() ?? fileConfig?.CommitSuffix,
             Prerelease = cliConfig.Prerelease.Value() ?? fileConfig?.Prerelease,
             AggregatePrereleases = MergeBool(cliConfig.AggregatePrereleases.HasValue(), fileConfig?.AggregatePrereleases),
+            FirstParentOnlyCommits = MergeBool(cliConfig.FirstParentOnlyCommits.HasValue(), fileConfig?.FirstParentOnlyCommits),
             CommitParser = commit,
             Project = project,
             UseCommitMessageInsteadOfTagToFindLastReleaseCommit = cliConfig.UseCommitMessageInsteadOfTagToFindLastReleaseCommit.HasValue(),
-            FirstParentOnlyCommit = MergeBool(cliConfig.FirstParentOnlyCommit.HasValue(), fileConfig?.FirstParentOnlyCommit),
         };
     }
 

--- a/Versionize/Config/FileConfig.cs
+++ b/Versionize/Config/FileConfig.cs
@@ -1,4 +1,4 @@
-﻿namespace Versionize.Config;
+namespace Versionize.Config;
 
 public sealed class FileConfig
 {
@@ -12,13 +12,13 @@ public sealed class FileConfig
     public bool? TagOnly { get; set; }
     public bool? IgnoreInsignificantCommits { get; set; }
     public bool? ExitInsignificantCommits { get; set; }
-    /// <summary>
-    /// The first parent only options allows you to ignore commits that are not the first parent.
-    /// </summary>
-    public bool? FirstParentOnlyCommit { get; set; }
     public string CommitSuffix { get; set; }
     public string Prerelease { get; set; }
     public bool? AggregatePrereleases { get; set; }
+    /// <summary>
+    /// Ignore commits beyond the first parent.
+    /// </summary>
+    public bool? FirstParentOnlyCommits { get; set; }
 
     public CommitParserOptions CommitParser { get; set; }
     public ProjectOptions[] Projects { get; set; } = [];

--- a/Versionize/Config/VersionizeOptions.cs
+++ b/Versionize/Config/VersionizeOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace Versionize.Config;
+namespace Versionize.Config;
 
 public sealed class VersionizeOptions
 {
@@ -14,6 +14,10 @@ public sealed class VersionizeOptions
     public string CommitSuffix { get; set; }
     public string Prerelease { get; set; }
     public bool AggregatePrereleases { get; set; }
+    /// <summary>
+    /// Ignore commits beyond the first parent.
+    /// </summary>
+    public bool FirstParentOnlyCommits { get; set; }
 
     public string WorkingDirectory { get; set; }
     public CommitParserOptions CommitParser { get; set; } = CommitParserOptions.Default;
@@ -28,9 +32,4 @@ public sealed class VersionizeOptions
     /// commit of the last release is to look for the last commit that contains a release message.
     /// </remarks>
     public bool UseCommitMessageInsteadOfTagToFindLastReleaseCommit { get; set; }
-
-    /// <summary>
-    /// The first parent only options allows you to ignore commits that are not the first parent.
-    /// </summary>
-    public bool FirstParentOnlyCommit { get; set; }
 }

--- a/Versionize/Lifecycle/ConventionalCommitProvider.cs
+++ b/Versionize/Lifecycle/ConventionalCommitProvider.cs
@@ -28,7 +28,7 @@ public sealed class ConventionalCommitProvider
         List<Commit> commitsInVersion;
         var commitFilter = new CommitFilter
         {
-            FirstParentOnly = options.FirstParentOnlyCommit
+            FirstParentOnly = options.FirstParentOnlyCommits
         };
 
         if (options.UseCommitMessageInsteadOfTagToFindLastReleaseCommit)
@@ -54,7 +54,7 @@ public sealed class ConventionalCommitProvider
         public ProjectOptions Project { get; init; }
         public bool AggregatePrereleases { get; init; }
         public bool UseCommitMessageInsteadOfTagToFindLastReleaseCommit { get; init; }
-        public bool FirstParentOnlyCommit { get; init; }
+        public bool FirstParentOnlyCommits { get; init; }
         public CommitParserOptions CommitParser { get; init; }
 
         public static implicit operator Options(VersionizeOptions versionizeOptions)
@@ -65,7 +65,7 @@ public sealed class ConventionalCommitProvider
                 CommitParser = versionizeOptions.CommitParser,
                 Project = versionizeOptions.Project,
                 UseCommitMessageInsteadOfTagToFindLastReleaseCommit = versionizeOptions.UseCommitMessageInsteadOfTagToFindLastReleaseCommit,
-                FirstParentOnlyCommit = versionizeOptions.FirstParentOnlyCommit,
+                FirstParentOnlyCommits = versionizeOptions.FirstParentOnlyCommits,
             };
         }
     }


### PR DESCRIPTION
@RemiCELLARD  Sorry, I missed this in the PR review. I'd like to keep the cli and file option names the same to minimize confusion. Trying to obey the following documentation snippet as closely as possible _(unfortunately there are already a few that don't match, so I guess we can consider those in the next major release)_.

> Any of the command line parameters accepted by versionize can be provided via configuration file leaving out any -. For example skip-dirty can be provided as skipDirty in the configuration file.

**Before**
```
--first-parent-commits
FirstParentOnlyCommit
```

**After**
```
--first-parent-only-commits
FirstParentOnlyCommits
```

This is technically a breaking change but v2 was released less than 24 hours ago and this is a brand new command, so I'm fine with bending the rules a bit by only making this a minor version bump.