### PR TITLE
fix: Changed regex for azure commits and issues to be in line with the current azure environment

### DIFF
--- a/Versionize.Tests/Changelog/AzureLinkBuilderTests.cs
+++ b/Versionize.Tests/Changelog/AzureLinkBuilderTests.cs
@@ -62,7 +62,7 @@ public class AzureLinkBuilderTests
         var linkBuilder = new AzureLinkBuilder("git@ssh.dev.azure.com:v3/dosse/DosSE.ERP.Cloud/ERP.git");
         var link = linkBuilder.BuildCommitLink(commit);
 
-        link.ShouldBe("https://v3@dev.azure.com/v3/dosse/DosSE.ERP.Cloud/ERP/commit/734713bc047d87bf7eac9674765ae793478c50d3");
+        link.ShouldBe("https://dosse@dev.azure.com/dosse/DosSE.ERP.Cloud/_git/ERP/commit/734713bc047d87bf7eac9674765ae793478c50d3");
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public class AzureLinkBuilderTests
         var linkBuilder = new AzureLinkBuilder("git@ssh.dev.azure.com:v3/dosse/DosSE.ERP.Cloud/ERP.git");
         var link = linkBuilder.BuildIssueLink("123");
 
-        link.ShouldBe("https://v3@dev.azure.com/v3/dosse/DosSE.ERP.Cloud/ERP/_workitems/edit/123");
+        link.ShouldBe("https://dosse@dev.azure.com/dosse/DosSE.ERP.Cloud/_workitems/edit/123");
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public class AzureLinkBuilderTests
         var linkBuilder = new AzureLinkBuilder("https://dosse@dev.azure.com/dosse/DosSE.ERP.Cloud/_git/ERP.git");
         var link = linkBuilder.BuildIssueLink("123");
 
-        link.ShouldBe("https://dosse@dev.azure.com/dosse/DosSE.ERP.Cloud/_git/ERP/_workitems/edit/123");
+        link.ShouldBe("https://dosse@dev.azure.com/dosse/DosSE.ERP.Cloud/_workitems/edit/123");
     }
 
     [Fact]

--- a/Versionize.Tests/Changelog/AzureLinkBuilderTests.cs
+++ b/Versionize.Tests/Changelog/AzureLinkBuilderTests.cs
@@ -62,7 +62,7 @@ public class AzureLinkBuilderTests
         var linkBuilder = new AzureLinkBuilder("git@ssh.dev.azure.com:v3/dosse/DosSE.ERP.Cloud/ERP.git");
         var link = linkBuilder.BuildCommitLink(commit);
 
-        link.ShouldBe("https://dosse@dev.azure.com/dosse/DosSE.ERP.Cloud/_git/ERP/commit/734713bc047d87bf7eac9674765ae793478c50d3");
+        link.ShouldBe("https://dev.azure.com/dosse/DosSE.ERP.Cloud/_git/ERP/commit/734713bc047d87bf7eac9674765ae793478c50d3");
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class AzureLinkBuilderTests
         var linkBuilder = new AzureLinkBuilder("https://dosse@dev.azure.com/dosse/DosSE.ERP.Cloud/_git/ERP.git");
         var link = linkBuilder.BuildCommitLink(commit);
 
-        link.ShouldBe("https://dosse@dev.azure.com/dosse/DosSE.ERP.Cloud/_git/ERP/commit/734713bc047d87bf7eac9674765ae793478c50d3");
+        link.ShouldBe("https://dev.azure.com/dosse/DosSE.ERP.Cloud/_git/ERP/commit/734713bc047d87bf7eac9674765ae793478c50d3");
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class AzureLinkBuilderTests
         var linkBuilder = new AzureLinkBuilder("https://dosse@dev.azure.com/dosse/DosSE.ERP.Cloud/_git/ERP.git");
         var link = linkBuilder.BuildVersionTagLink(semVer);
 
-        link.ShouldBe("https://dosse@dev.azure.com/dosse/DosSE.ERP.Cloud/_git/ERP?version=GTv1.2.3");
+        link.ShouldBe("https://dev.azure.com/dosse/DosSE.ERP.Cloud/_git/ERP?version=GTv1.2.3");
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public class AzureLinkBuilderTests
         var linkBuilder = new AzureLinkBuilder("git@ssh.dev.azure.com:v3/dosse/DosSE.ERP.Cloud/ERP.git");
         var link = linkBuilder.BuildIssueLink("123");
 
-        link.ShouldBe("https://dosse@dev.azure.com/dosse/DosSE.ERP.Cloud/_workitems/edit/123");
+        link.ShouldBe("https://dev.azure.com/dosse/DosSE.ERP.Cloud/_workitems/edit/123");
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public class AzureLinkBuilderTests
         var linkBuilder = new AzureLinkBuilder("https://dosse@dev.azure.com/dosse/DosSE.ERP.Cloud/_git/ERP.git");
         var link = linkBuilder.BuildIssueLink("123");
 
-        link.ShouldBe("https://dosse@dev.azure.com/dosse/DosSE.ERP.Cloud/_workitems/edit/123");
+        link.ShouldBe("https://dev.azure.com/dosse/DosSE.ERP.Cloud/_workitems/edit/123");
     }
 
     [Fact]

--- a/Versionize/Changelog/AzureLinkBuilder.cs
+++ b/Versionize/Changelog/AzureLinkBuilder.cs
@@ -52,17 +52,17 @@ public sealed partial class AzureLinkBuilder : IChangelogLinkBuilder
 
     public string BuildVersionTagLink(Version version)
     {
-        return $"https://{_organization}@dev.azure.com/{_organization}/{_project}/_git/{_repository}?version=GTv{version}";
+        return $"https://dev.azure.com/{_organization}/{_project}/_git/{_repository}?version=GTv{version}";
     }
 
     public string BuildIssueLink(string issueId)
     {
-        return $"https://{_organization}@dev.azure.com/{_organization}/{_project}/_workitems/edit/{issueId}";
+        return $"https://dev.azure.com/{_organization}/{_project}/_workitems/edit/{issueId}";
     }
 
     public string BuildCommitLink(ConventionalCommit commit)
     {
-        return $"https://{_organization}@dev.azure.com/{_organization}/{_project}/_git/{_repository}/commit/{commit.Sha}";
+        return $"https://dev.azure.com/{_organization}/{_project}/_git/{_repository}/commit/{commit.Sha}";
     }
 
     [GeneratedRegex("^git@ssh.dev.azure.com(?<version>.*?)/(?<organization>.*?)/(?<project>.*?)/(?<repository>.*?)(?:\\.git)?$")]

--- a/Versionize/Changelog/AzureLinkBuilder.cs
+++ b/Versionize/Changelog/AzureLinkBuilder.cs
@@ -65,7 +65,7 @@ public sealed partial class AzureLinkBuilder : IChangelogLinkBuilder
         return $"https://dev.azure.com/{_organization}/{_project}/_git/{_repository}/commit/{commit.Sha}";
     }
 
-    [GeneratedRegex("^git@ssh.dev.azure.com(?<version>.*?)/(?<organization>.*?)/(?<project>.*?)/(?<repository>.*?)(?:\\.git)?$")]
+    [GeneratedRegex("^git@ssh.dev.azure.com:(?<version>.*?)/(?<organization>.*?)/(?<project>.*?)/(?<repository>.*?)(?:\\.git)?$")]
     private static partial Regex SshRegex();
 
     [GeneratedRegex("^https://(?<organization>.*?)@dev.azure.com/(?<organization>.*?)/(?<project>.*?)/_git/(?<repository>.*?)(?:\\.git)?$")]

--- a/Versionize/Changelog/AzureLinkBuilder.cs
+++ b/Versionize/Changelog/AzureLinkBuilder.cs
@@ -8,6 +8,7 @@ public sealed partial class AzureLinkBuilder : IChangelogLinkBuilder
 {
     private readonly string _organization;
     private readonly string _repository;
+    private readonly string _project;
 
     public AzureLinkBuilder(string pushUrl)
     {
@@ -23,6 +24,7 @@ public sealed partial class AzureLinkBuilder : IChangelogLinkBuilder
 
             _organization = matches.Groups["organization"].Value;
             _repository = matches.Groups["repository"].Value;
+            _project = matches.Groups["project"].Value;
         }
         else if (pushUrl.StartsWith("https://") && pushUrl.Contains("@dev.azure.com/"))
         {
@@ -35,6 +37,7 @@ public sealed partial class AzureLinkBuilder : IChangelogLinkBuilder
             }
             _organization = matches.Groups["organization"].Value;
             _repository = matches.Groups["repository"].Value;
+            _project = matches.Groups["project"].Value;
         }
         else
         {
@@ -49,22 +52,22 @@ public sealed partial class AzureLinkBuilder : IChangelogLinkBuilder
 
     public string BuildVersionTagLink(Version version)
     {
-        return $"https://{_organization}@dev.azure.com/{_organization}/{_repository}?version=GTv{version}";
+        return $"https://{_organization}@dev.azure.com/{_organization}/{_project}/_git/{_repository}?version=GTv{version}";
     }
 
     public string BuildIssueLink(string issueId)
     {
-        return $"https://{_organization}@dev.azure.com/{_organization}/{_repository}/_workitems/edit/{issueId}";
+        return $"https://{_organization}@dev.azure.com/{_organization}/{_project}/_workitems/edit/{issueId}";
     }
 
     public string BuildCommitLink(ConventionalCommit commit)
     {
-        return $"https://{_organization}@dev.azure.com/{_organization}/{_repository}/commit/{commit.Sha}";
+        return $"https://{_organization}@dev.azure.com/{_organization}/{_project}/_git/{_repository}/commit/{commit.Sha}";
     }
 
-    [GeneratedRegex("^git@ssh.dev.azure.com:(?<organization>.*?)/(?<repository>.*?)(?:\\.git)?$")]
+    [GeneratedRegex("^git@ssh.dev.azure.com(?<version>.*?)/(?<organization>.*?)/(?<project>.*?)/(?<repository>.*?)(?:\\.git)?$")]
     private static partial Regex SshRegex();
 
-    [GeneratedRegex("^https://(?<organization>.*?)@dev.azure.com/(?<organization>.*?)/(?<repository>.*?)(?:\\.git)?$")]
+    [GeneratedRegex("^https://(?<organization>.*?)@dev.azure.com/(?<organization>.*?)/(?<project>.*?)/_git/(?<repository>.*?)(?:\\.git)?$")]
     private static partial Regex HttpsRegex();
 }


### PR DESCRIPTION
The pull request fixes the urls build for the changelog using Azure, urls included company multiple times /_git/ for work items.
These 2 parts of the url made it so that the links don't work. 