### PR TITLE
feat: add support for JIRA issues

### DIFF
--- a/Versionize/Config/CommitParserOptions.cs
+++ b/Versionize/Config/CommitParserOptions.cs
@@ -6,6 +6,8 @@ public sealed class CommitParserOptions
 
     public string[] HeaderPatterns { get; set; } = [];
 
+    public string[] IssuesPatterns { get; set; } = [];
+
     public static CommitParserOptions Merge(CommitParserOptions? customOptions, CommitParserOptions defaultOptions)
     {
         if (customOptions == null)
@@ -16,6 +18,7 @@ public sealed class CommitParserOptions
         return new CommitParserOptions
         {
             HeaderPatterns = customOptions.HeaderPatterns ?? defaultOptions.HeaderPatterns,
+            IssuesPatterns = customOptions.IssuesPatterns ?? defaultOptions.IssuesPatterns,
         };
     }
 }

--- a/Versionize/ConventionalCommits/ConventionalCommitParser.cs
+++ b/Versionize/ConventionalCommits/ConventionalCommitParser.cs
@@ -54,6 +54,11 @@ public static class ConventionalCommitParser
             DefaultHeaderPattern
         };
 
+        var issuesPatterns = new List<string>(options?.IssuesPatterns ?? [])
+        {
+            DefaultIssuesPattern
+        };
+
         Match? headerMatch = null;
         foreach (var headerPattern in headerPatterns)
         {
@@ -79,15 +84,18 @@ public static class ConventionalCommitParser
                 });
             }
 
-            var issuesMatch = Regex.Matches(conventionalCommit.Subject, DefaultIssuesPattern, RegexOptions);
-            foreach (var issueMatch in issuesMatch.Cast<Match>())
+            foreach (var issuesPattern in issuesPatterns)
             {
-                conventionalCommit.Issues.Add(
-                    new ConventionalCommitIssue
-                    {
-                        Token = issueMatch.Groups["issueToken"].Value,
-                        Id = issueMatch.Groups["issueId"].Value,
-                    });
+                var issuesMatch = Regex.Matches(conventionalCommit.Subject, issuesPattern, RegexOptions);
+                foreach (var issueMatch in issuesMatch.Cast<Match>())
+                {
+                    conventionalCommit.Issues.Add(
+                        new ConventionalCommitIssue
+                        {
+                            Token = issueMatch.Groups["issueToken"].Value,
+                            Id = issueMatch.Groups["issueId"].Value,
+                        });
+                }
             }
         }
         else


### PR DESCRIPTION
Adds support for JIRA issues within commits via a new _CommitParserOptions_ `IssuesPatterns` property, used to extend the default issues pattern.

Usage:
```json
{
  "CommitParser": {
    "IssuesPatterns": [
      "(?<issueToken>(?<issueId>[A-Z]+\\-\\d+))"
    ]
  }
}
```

With this, commit messages like the following:
> fix: subject text. (NC-64)

will correctly identify JIRA issue **NC-64**

Remaining hooks into JIRA would then be dependent on configuration of _chagnelog/linkTemplates/issueLink_ to resolve to the specific JIRA issue URL.