### PR TITLE
feat: add Git configuration checks for versioning operations

### DIFF
--- a/Versionize/Config/VersionizeOptions.cs
+++ b/Versionize/Config/VersionizeOptions.cs
@@ -33,4 +33,9 @@ public sealed class VersionizeOptions
     /// commit of the last release is to look for the last commit that contains a release message.
     /// </remarks>
     public bool UseCommitMessageInsteadOfTagToFindLastReleaseCommit { get; set; }
+
+    public bool IsCommitConfigurationRequired()
+    {
+        return (!SkipCommit || !SkipTag) && !DryRun;
+    }
 }

--- a/Versionize/WorkingCopy.cs
+++ b/Versionize/WorkingCopy.cs
@@ -71,7 +71,8 @@ public class WorkingCopy
         var gitDirectory = _gitDirectory.FullName;
         var repo = new Repository(gitDirectory);
 
-        if (!repo.IsConfiguredForCommits())
+        // Only check Git configuration if we will perform Git operations (commit or tag)
+        if (options.IsCommitConfigurationRequired() && !repo.IsConfiguredForCommits())
         {
             Exit(@"Warning: Git configuration is missing. Please configure git before running versionize:
 git config --global user.name ""John Doe""


### PR DESCRIPTION
fixes "--skip-commit --skip-tag" still enforces Git config Fixes #167