### PR TITLE
feat: add support for printing tag version when tag-only option is used in inspect command

### DIFF
--- a/Versionize.Tests/FunctionalTests/Program.InspectCommandTests.cs
+++ b/Versionize.Tests/FunctionalTests/Program.InspectCommandTests.cs
@@ -36,6 +36,24 @@ public class InspectCommandTests : IDisposable
     }
 
     [Fact]
+    public void ShouldPrintTagVersionWhenTagOnlyIsUsed()
+    {
+        // Arrange
+        TempProject.CreateCsharpProject(_testSetup.WorkingDirectory, "1.1.0");
+        GitTestHelpers.CommitAll(_testSetup.Repository, "feat: initial commit");
+        _testSetup.Repository.Tags.Add("v2.0.0", _testSetup.Repository.Head.Tip);
+
+        // Act
+        var exitCode = Program.Main(
+            ["--workingDir", _testSetup.WorkingDirectory, "--tag-only", "inspect"]);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        _testPlatformAbstractions.Messages.ShouldHaveSingleItem();
+        _testPlatformAbstractions.Messages[0].ShouldBe("2.0.0");
+    }
+
+    [Fact]
     public void ShouldPrintTheCurrentMonoRepoVersionWithInspectCommand()
     {
         var projects = new[]

--- a/Versionize/Commands/InspectCommand.cs
+++ b/Versionize/Commands/InspectCommand.cs
@@ -1,16 +1,11 @@
-using McMaster.Extensions.CommandLineUtils;
+﻿using McMaster.Extensions.CommandLineUtils;
 using Versionize.CommandLine;
 using Versionize.Commands;
 
 [Command(Name = "inspect", Description = "Prints the current version to stdout")]
-internal sealed class InspectCommand
+internal sealed class InspectCommand(IInspectCmdContextProvider contextProvider)
 {
-    private readonly IInspectCmdContextProvider _contextProvider;
-
-    public InspectCommand(IInspectCmdContextProvider contextProvider)
-    {
-        _contextProvider = contextProvider;
-    }
+    private readonly IInspectCmdContextProvider _contextProvider = contextProvider;
 
     public void OnExecute()
     {
@@ -18,7 +13,7 @@ internal sealed class InspectCommand
         InspectCmdContext context = _contextProvider.GetContext();
         CommandLineUI.Verbosity = LogLevel.All;
 
-        // TODO: Support getting version from tag
-        CommandLineUI.Information(context.BumpFile?.Version.ToNormalizedString() ?? "");
+        var version = context.GetCurrentVersion();
+        CommandLineUI.Information(version?.ToNormalizedString() ?? "");
     }
 }


### PR DESCRIPTION
Not sure how useful this is, but it was super simple to implement with the given architecture.

Closes #128 