### PR TITLE
Fix Windows tool-managed entries in repository dirty check

### DIFF
--- a/Versionize.Tests/Git/RepoStateValidatorTests.cs
+++ b/Versionize.Tests/Git/RepoStateValidatorTests.cs
@@ -4,6 +4,7 @@ using Versionize.CommandLine;
 using Versionize.Git;
 using Versionize.Tests.TestSupport;
 using Xunit;
+using static LibGit2Sharp.FileStatus;
 
 namespace Versionize;
 
@@ -63,6 +64,194 @@ public partial class RepoStateValidatorTests : IDisposable
         // Act/Assert
         Should.Throw<VersionizeException>(() => sut.Validate(_testSetup.Repository, options))
             .Message.ShouldBe(ErrorMessages.RepositoryDirty(_testSetup.WorkingDirectory, "NewInIndex: hello.txt"));
+    }
+
+    [Theory]
+    [InlineData(".claude")]
+    [InlineData(".agent")]
+    [InlineData(".agents")]
+    [InlineData(".cursor")]
+    [InlineData(".winsurf")]
+    [InlineData(".windsurf")]
+    [InlineData(".opencode")]
+    [InlineData(".codex")]
+    public void ShouldIgnoreTrackedToolSymlinkChangesInAllowedDirectories(string toolDirectory)
+    {
+        if (!OperatingSystem.IsWindows() || !TryReplaceTrackedFileWithSymlink(Path.Join(toolDirectory, "SKILL.md")))
+        {
+            return;
+        }
+
+        var sut = new RepoStateValidator();
+        var options = new IRepoStateValidator.Options
+        {
+            WorkingDirectory = _testSetup.WorkingDirectory,
+            SkipCommit = false,
+            SkipTag = false,
+            SkipDirty = false,
+            DryRun = false
+        };
+
+        Should.NotThrow(() => sut.Validate(_testSetup.Repository, options));
+        _testPlatformAbstractions.Messages.ShouldContain(InfoMessages.IgnoredToolSymlinks(1));
+        _testPlatformAbstractions.Messages.ShouldContain($"  * {NormalizeGitPath(Path.Join(toolDirectory, "SKILL.md"))}");
+    }
+
+    [Fact]
+    public void ShouldIgnoreToolSymlinksButStillFailForOtherDirtyFiles()
+    {
+        if (!OperatingSystem.IsWindows() || !TryReplaceTrackedFileWithSymlink(Path.Join(".claude", "SKILL.md")))
+        {
+            return;
+        }
+
+        File.WriteAllText(Path.Join(_testSetup.WorkingDirectory, "hello.txt"), "hello world");
+        LibGit2Sharp.Commands.Stage(_testSetup.Repository, "hello.txt");
+
+        var sut = new RepoStateValidator();
+        var options = new IRepoStateValidator.Options
+        {
+            WorkingDirectory = _testSetup.WorkingDirectory,
+            SkipCommit = false,
+            SkipTag = false,
+            SkipDirty = false,
+            DryRun = false
+        };
+
+        var exception = Should.Throw<VersionizeException>(() => sut.Validate(_testSetup.Repository, options));
+        exception.Message.ShouldBe(ErrorMessages.RepositoryDirty(_testSetup.WorkingDirectory, "NewInIndex: hello.txt"));
+        _testPlatformAbstractions.Messages.ShouldContain(InfoMessages.IgnoredToolSymlinks(1));
+        _testPlatformAbstractions.Messages.ShouldContain("  * .claude/SKILL.md");
+    }
+
+    [Fact]
+    public void ShouldTreatSymlinkOutsideAllowedDirectoriesAsDirty()
+    {
+        if (!OperatingSystem.IsWindows() || !TryReplaceTrackedFileWithSymlink(Path.Join(".tools", "SKILL.md")))
+        {
+            return;
+        }
+
+        var sut = new RepoStateValidator();
+        var options = new IRepoStateValidator.Options
+        {
+            WorkingDirectory = _testSetup.WorkingDirectory,
+            SkipCommit = false,
+            SkipTag = false,
+            SkipDirty = false,
+            DryRun = false
+        };
+
+        Should.Throw<VersionizeException>(() => sut.Validate(_testSetup.Repository, options))
+            .Message.ShouldContain(".tools/SKILL.md");
+    }
+
+    [Fact]
+    public void ShouldWarnWithCorrectCountForMultipleIgnoredToolSymlinks()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var firstCreated = TryReplaceTrackedFileWithSymlink(Path.Join(".claude", "SKILL.md"));
+        var secondCreated = TryReplaceTrackedFileWithSymlink(Path.Join(".cursor", "AGENTS.md"));
+        if (!firstCreated || !secondCreated)
+        {
+            return;
+        }
+
+        var sut = new RepoStateValidator();
+        var options = new IRepoStateValidator.Options
+        {
+            WorkingDirectory = _testSetup.WorkingDirectory,
+            SkipCommit = false,
+            SkipTag = false,
+            SkipDirty = false,
+            DryRun = false
+        };
+
+        Should.NotThrow(() => sut.Validate(_testSetup.Repository, options));
+        _testPlatformAbstractions.Messages.ShouldContain(InfoMessages.IgnoredToolSymlinks(2));
+        _testPlatformAbstractions.Messages.ShouldContain("  * .claude/SKILL.md");
+        _testPlatformAbstractions.Messages.ShouldContain("  * .cursor/AGENTS.md");
+    }
+
+    [Fact]
+    public void ShouldNotListIgnoredToolSymlinksWhenOutputIsSilent()
+    {
+        if (!OperatingSystem.IsWindows() || !TryReplaceTrackedFileWithSymlink(Path.Join(".claude", "SKILL.md")))
+        {
+            return;
+        }
+
+        CommandLineUI.Verbosity = Versionize.CommandLine.LogLevel.Silent;
+
+        var sut = new RepoStateValidator();
+        var options = new IRepoStateValidator.Options
+        {
+            WorkingDirectory = _testSetup.WorkingDirectory,
+            SkipCommit = false,
+            SkipTag = false,
+            SkipDirty = false,
+            DryRun = false
+        };
+
+        Should.NotThrow(() => sut.Validate(_testSetup.Repository, options));
+        _testPlatformAbstractions.Messages.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ShouldDetectRealWindowsSymlinkInTestSymLinkFolder()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var testSymLinkDirectory = Path.Join(_testSetup.WorkingDirectory, "testSymLink");
+        var claudeDirectory = Path.Join(testSymLinkDirectory, ".claude");
+        var agentDirectory = Path.Join(testSymLinkDirectory, ".agent");
+        Directory.CreateDirectory(claudeDirectory);
+        Directory.CreateDirectory(agentDirectory);
+
+        var realFilePath = Path.Join(claudeDirectory, "real.txt");
+        var symlinkPath = Path.Join(agentDirectory, "real.txt");
+        File.WriteAllText(realFilePath, "real file content");
+
+        CreateFileSymlinkOrThrow(symlinkPath, realFilePath);
+
+        File.Exists(symlinkPath).ShouldBeTrue();
+        File.GetAttributes(symlinkPath).HasFlag(FileAttributes.ReparsePoint).ShouldBeTrue();
+        RepoStateValidator.IsWindowsSymlink(symlinkPath).ShouldBeTrue();
+        RepoStateValidator.IsWindowsSymlink(realFilePath).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldRecognizeExistingDeletedFromWorkdirEntryInToolDirectoryAsIgnorable()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var testSymLinkDirectory = Path.Join(_testSetup.WorkingDirectory, "testSymLink");
+        var agentDirectory = Path.Join(testSymLinkDirectory, ".agent");
+        Directory.CreateDirectory(agentDirectory);
+
+        var existingFilePath = Path.Join(agentDirectory, "real.txt");
+        File.WriteAllText(existingFilePath, "real file content");
+
+        var repositoryRoot = Path.GetFullPath(testSymLinkDirectory);
+        var fullPath = Path.GetFullPath(existingFilePath);
+
+        RepoStateValidator.IsToolDirectoryPath(fullPath, repositoryRoot).ShouldBeTrue();
+        RepoStateValidator.PathExists(fullPath).ShouldBeTrue();
+        RepoStateValidator.IsWindowsSymlink(fullPath).ShouldBeFalse();
+        RepoStateValidator.IsIgnoredExistingToolEntry(
+            ".agent/real.txt",
+            DeletedFromWorkdir,
+            repositoryRoot).ShouldBeTrue();
     }
 
     [Fact]
@@ -208,4 +397,67 @@ public partial class RepoStateValidatorTests : IDisposable
     {
         _testSetup.Dispose();
     }
+
+    private bool TryReplaceTrackedFileWithSymlink(string relativePath)
+    {
+        var fullPath = Path.Join(_testSetup.WorkingDirectory, relativePath);
+        var directory = Path.GetDirectoryName(fullPath);
+        directory.ShouldNotBeNull();
+        Directory.CreateDirectory(directory);
+
+        File.WriteAllText(fullPath, "tracked");
+        CommitPath(relativePath, $"feat: add {relativePath}");
+
+        var targetPath = Path.Join(_testSetup.WorkingDirectory, Path.GetFileNameWithoutExtension(relativePath) + ".target.txt");
+        File.WriteAllText(targetPath, "target");
+
+        File.Delete(fullPath);
+
+        try
+        {
+            CreateFileSymlinkOrThrow(fullPath, targetPath);
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private void CommitPath(string relativePath, string message)
+    {
+        LibGit2Sharp.Commands.Stage(_testSetup.Repository, NormalizeGitPath(relativePath));
+
+        var user = _testSetup.Repository.Config.Get<string>("user.name")?.Value;
+        var email = _testSetup.Repository.Config.Get<string>("user.email")?.Value;
+        var signature = new Signature(user, email, DateTimeOffset.Now);
+
+        _testSetup.Repository.Commit(message, signature, signature);
+    }
+
+    private static string NormalizeGitPath(string path)
+    {
+        return path.Replace('\\', '/');
+    }
+
+    private static void CreateFileSymlinkOrThrow(string symlinkPath, string targetPath)
+    {
+        try
+        {
+            File.CreateSymbolicLink(symlinkPath, targetPath);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            throw new InvalidOperationException("Could not create the Windows symbolic link required for this test.", ex);
+        }
+        catch (IOException ex)
+        {
+            throw new InvalidOperationException("Could not create the Windows symbolic link required for this test.", ex);
+        }
+        catch (PlatformNotSupportedException ex)
+        {
+            throw new InvalidOperationException("Could not create the Windows symbolic link required for this test.", ex);
+        }
+    }
+
 }

--- a/Versionize.Tests/Git/RepoStateValidatorTests.cs
+++ b/Versionize.Tests/Git/RepoStateValidatorTests.cs
@@ -4,6 +4,7 @@ using Versionize.CommandLine;
 using Versionize.Git;
 using Versionize.Tests.TestSupport;
 using Xunit;
+using Xunit.Sdk;
 using static LibGit2Sharp.FileStatus;
 
 namespace Versionize;
@@ -77,10 +78,8 @@ public partial class RepoStateValidatorTests : IDisposable
     [InlineData(".codex")]
     public void ShouldIgnoreTrackedToolSymlinkChangesInAllowedDirectories(string toolDirectory)
     {
-        if (!OperatingSystem.IsWindows() || !TryReplaceTrackedFileWithSymlink(Path.Join(toolDirectory, "SKILL.md")))
-        {
-            return;
-        }
+        RequireWindows();
+        ReplaceTrackedFileWithSymlinkOrSkip(Path.Join(toolDirectory, "SKILL.md"));
 
         var sut = new RepoStateValidator();
         var options = new IRepoStateValidator.Options
@@ -93,17 +92,15 @@ public partial class RepoStateValidatorTests : IDisposable
         };
 
         Should.NotThrow(() => sut.Validate(_testSetup.Repository, options));
-        _testPlatformAbstractions.Messages.ShouldContain(InfoMessages.IgnoredToolSymlinks(1));
+        _testPlatformAbstractions.Messages.ShouldContain(InfoMessages.IgnoredToolSymlinks(1, RepoStateValidator.IgnoredToolDirectoryList));
         _testPlatformAbstractions.Messages.ShouldContain($"  * {NormalizeGitPath(Path.Join(toolDirectory, "SKILL.md"))}");
     }
 
     [Fact]
     public void ShouldIgnoreToolSymlinksButStillFailForOtherDirtyFiles()
     {
-        if (!OperatingSystem.IsWindows() || !TryReplaceTrackedFileWithSymlink(Path.Join(".claude", "SKILL.md")))
-        {
-            return;
-        }
+        RequireWindows();
+        ReplaceTrackedFileWithSymlinkOrSkip(Path.Join(".claude", "SKILL.md"));
 
         File.WriteAllText(Path.Join(_testSetup.WorkingDirectory, "hello.txt"), "hello world");
         LibGit2Sharp.Commands.Stage(_testSetup.Repository, "hello.txt");
@@ -120,17 +117,15 @@ public partial class RepoStateValidatorTests : IDisposable
 
         var exception = Should.Throw<VersionizeException>(() => sut.Validate(_testSetup.Repository, options));
         exception.Message.ShouldBe(ErrorMessages.RepositoryDirty(_testSetup.WorkingDirectory, "NewInIndex: hello.txt"));
-        _testPlatformAbstractions.Messages.ShouldContain(InfoMessages.IgnoredToolSymlinks(1));
+        _testPlatformAbstractions.Messages.ShouldContain(InfoMessages.IgnoredToolSymlinks(1, RepoStateValidator.IgnoredToolDirectoryList));
         _testPlatformAbstractions.Messages.ShouldContain("  * .claude/SKILL.md");
     }
 
     [Fact]
     public void ShouldTreatSymlinkOutsideAllowedDirectoriesAsDirty()
     {
-        if (!OperatingSystem.IsWindows() || !TryReplaceTrackedFileWithSymlink(Path.Join(".tools", "SKILL.md")))
-        {
-            return;
-        }
+        RequireWindows();
+        ReplaceTrackedFileWithSymlinkOrSkip(Path.Join(".tools", "SKILL.md"));
 
         var sut = new RepoStateValidator();
         var options = new IRepoStateValidator.Options
@@ -149,17 +144,9 @@ public partial class RepoStateValidatorTests : IDisposable
     [Fact]
     public void ShouldWarnWithCorrectCountForMultipleIgnoredToolSymlinks()
     {
-        if (!OperatingSystem.IsWindows())
-        {
-            return;
-        }
-
-        var firstCreated = TryReplaceTrackedFileWithSymlink(Path.Join(".claude", "SKILL.md"));
-        var secondCreated = TryReplaceTrackedFileWithSymlink(Path.Join(".cursor", "AGENTS.md"));
-        if (!firstCreated || !secondCreated)
-        {
-            return;
-        }
+        RequireWindows();
+        ReplaceTrackedFileWithSymlinkOrSkip(Path.Join(".claude", "SKILL.md"));
+        ReplaceTrackedFileWithSymlinkOrSkip(Path.Join(".cursor", "AGENTS.md"));
 
         var sut = new RepoStateValidator();
         var options = new IRepoStateValidator.Options
@@ -172,7 +159,7 @@ public partial class RepoStateValidatorTests : IDisposable
         };
 
         Should.NotThrow(() => sut.Validate(_testSetup.Repository, options));
-        _testPlatformAbstractions.Messages.ShouldContain(InfoMessages.IgnoredToolSymlinks(2));
+        _testPlatformAbstractions.Messages.ShouldContain(InfoMessages.IgnoredToolSymlinks(2, RepoStateValidator.IgnoredToolDirectoryList));
         _testPlatformAbstractions.Messages.ShouldContain("  * .claude/SKILL.md");
         _testPlatformAbstractions.Messages.ShouldContain("  * .cursor/AGENTS.md");
     }
@@ -180,10 +167,8 @@ public partial class RepoStateValidatorTests : IDisposable
     [Fact]
     public void ShouldNotListIgnoredToolSymlinksWhenOutputIsSilent()
     {
-        if (!OperatingSystem.IsWindows() || !TryReplaceTrackedFileWithSymlink(Path.Join(".claude", "SKILL.md")))
-        {
-            return;
-        }
+        RequireWindows();
+        ReplaceTrackedFileWithSymlinkOrSkip(Path.Join(".claude", "SKILL.md"));
 
         CommandLineUI.Verbosity = Versionize.CommandLine.LogLevel.Silent;
 
@@ -204,10 +189,7 @@ public partial class RepoStateValidatorTests : IDisposable
     [Fact]
     public void ShouldDetectRealWindowsSymlinkInTestSymLinkFolder()
     {
-        if (!OperatingSystem.IsWindows())
-        {
-            return;
-        }
+        RequireWindows();
 
         var testSymLinkDirectory = Path.Join(_testSetup.WorkingDirectory, "testSymLink");
         var claudeDirectory = Path.Join(testSymLinkDirectory, ".claude");
@@ -223,17 +205,14 @@ public partial class RepoStateValidatorTests : IDisposable
 
         File.Exists(symlinkPath).ShouldBeTrue();
         File.GetAttributes(symlinkPath).HasFlag(FileAttributes.ReparsePoint).ShouldBeTrue();
-        RepoStateValidator.IsWindowsSymlink(symlinkPath).ShouldBeTrue();
-        RepoStateValidator.IsWindowsSymlink(realFilePath).ShouldBeFalse();
+        RepoStateValidator.IsWindowsReparsePoint(symlinkPath).ShouldBeTrue();
+        RepoStateValidator.IsWindowsReparsePoint(realFilePath).ShouldBeFalse();
     }
 
     [Fact]
     public void ShouldRecognizeExistingDeletedFromWorkdirEntryInToolDirectoryAsIgnorable()
     {
-        if (!OperatingSystem.IsWindows())
-        {
-            return;
-        }
+        RequireWindows();
 
         var testSymLinkDirectory = Path.Join(_testSetup.WorkingDirectory, "testSymLink");
         var agentDirectory = Path.Join(testSymLinkDirectory, ".agent");
@@ -247,7 +226,7 @@ public partial class RepoStateValidatorTests : IDisposable
 
         RepoStateValidator.IsToolDirectoryPath(fullPath, repositoryRoot).ShouldBeTrue();
         RepoStateValidator.PathExists(fullPath).ShouldBeTrue();
-        RepoStateValidator.IsWindowsSymlink(fullPath).ShouldBeFalse();
+        RepoStateValidator.IsWindowsReparsePoint(fullPath).ShouldBeFalse();
         RepoStateValidator.IsIgnoredExistingToolEntry(
             ".agent/real.txt",
             DeletedFromWorkdir,
@@ -398,7 +377,7 @@ public partial class RepoStateValidatorTests : IDisposable
         _testSetup.Dispose();
     }
 
-    private bool TryReplaceTrackedFileWithSymlink(string relativePath)
+    private void ReplaceTrackedFileWithSymlinkOrSkip(string relativePath)
     {
         var fullPath = Path.Join(_testSetup.WorkingDirectory, relativePath);
         var directory = Path.GetDirectoryName(fullPath);
@@ -416,11 +395,10 @@ public partial class RepoStateValidatorTests : IDisposable
         try
         {
             CreateFileSymlinkOrThrow(fullPath, targetPath);
-            return true;
         }
-        catch (InvalidOperationException)
+        catch (SkipException)
         {
-            return false;
+            throw;
         }
     }
 
@@ -448,16 +426,34 @@ public partial class RepoStateValidatorTests : IDisposable
         }
         catch (UnauthorizedAccessException ex)
         {
-            throw new InvalidOperationException("Could not create the Windows symbolic link required for this test.", ex);
+            throw Skip(ex);
         }
         catch (IOException ex)
         {
-            throw new InvalidOperationException("Could not create the Windows symbolic link required for this test.", ex);
+            throw Skip(ex);
         }
         catch (PlatformNotSupportedException ex)
         {
-            throw new InvalidOperationException("Could not create the Windows symbolic link required for this test.", ex);
+            throw Skip(ex);
         }
+    }
+
+    private static void RequireWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            throw SkipException.ForSkip("Windows-only test.");
+        }
+    }
+
+    private static SkipException Skip()
+    {
+        return SkipException.ForSkip("Windows symbolic links are not available in the current test environment.");
+    }
+
+    private static SkipException Skip(Exception ex)
+    {
+        return SkipException.ForSkip($"Windows symbolic links are not available in the current test environment. {ex.GetType().Name}: {ex.Message}");
     }
 
 }

--- a/Versionize.Tests/Git/RepoStateValidatorTests.cs
+++ b/Versionize.Tests/Git/RepoStateValidatorTests.cs
@@ -391,15 +391,7 @@ public partial class RepoStateValidatorTests : IDisposable
         File.WriteAllText(targetPath, "target");
 
         File.Delete(fullPath);
-
-        try
-        {
-            CreateFileSymlinkOrThrow(fullPath, targetPath);
-        }
-        catch (SkipException)
-        {
-            throw;
-        }
+        CreateFileSymlinkOrThrow(fullPath, targetPath);
     }
 
     private void CommitPath(string relativePath, string message)

--- a/Versionize.Tests/Git/RepoStateValidatorTests.cs
+++ b/Versionize.Tests/Git/RepoStateValidatorTests.cs
@@ -4,7 +4,6 @@ using Versionize.CommandLine;
 using Versionize.Git;
 using Versionize.Tests.TestSupport;
 using Xunit;
-using Xunit.Sdk;
 using static LibGit2Sharp.FileStatus;
 
 namespace Versionize;
@@ -67,7 +66,7 @@ public partial class RepoStateValidatorTests : IDisposable
             .Message.ShouldBe(ErrorMessages.RepositoryDirty(_testSetup.WorkingDirectory, "NewInIndex: hello.txt"));
     }
 
-    [Theory]
+    [WindowsOnlyTheory]
     [InlineData(".claude")]
     [InlineData(".agent")]
     [InlineData(".agents")]
@@ -78,8 +77,7 @@ public partial class RepoStateValidatorTests : IDisposable
     [InlineData(".codex")]
     public void ShouldIgnoreTrackedToolSymlinkChangesInAllowedDirectories(string toolDirectory)
     {
-        RequireWindows();
-        ReplaceTrackedFileWithSymlinkOrSkip(Path.Join(toolDirectory, "SKILL.md"));
+        ReplaceTrackedFileWithSymlink(Path.Join(toolDirectory, "SKILL.md"));
 
         var sut = new RepoStateValidator();
         var options = new IRepoStateValidator.Options
@@ -96,11 +94,10 @@ public partial class RepoStateValidatorTests : IDisposable
         _testPlatformAbstractions.Messages.ShouldContain($"  * {NormalizeGitPath(Path.Join(toolDirectory, "SKILL.md"))}");
     }
 
-    [Fact]
+    [WindowsOnlyFact]
     public void ShouldIgnoreToolSymlinksButStillFailForOtherDirtyFiles()
     {
-        RequireWindows();
-        ReplaceTrackedFileWithSymlinkOrSkip(Path.Join(".claude", "SKILL.md"));
+        ReplaceTrackedFileWithSymlink(Path.Join(".claude", "SKILL.md"));
 
         File.WriteAllText(Path.Join(_testSetup.WorkingDirectory, "hello.txt"), "hello world");
         LibGit2Sharp.Commands.Stage(_testSetup.Repository, "hello.txt");
@@ -121,11 +118,10 @@ public partial class RepoStateValidatorTests : IDisposable
         _testPlatformAbstractions.Messages.ShouldContain("  * .claude/SKILL.md");
     }
 
-    [Fact]
+    [WindowsOnlyFact]
     public void ShouldTreatSymlinkOutsideAllowedDirectoriesAsDirty()
     {
-        RequireWindows();
-        ReplaceTrackedFileWithSymlinkOrSkip(Path.Join(".tools", "SKILL.md"));
+        ReplaceTrackedFileWithSymlink(Path.Join(".tools", "SKILL.md"));
 
         var sut = new RepoStateValidator();
         var options = new IRepoStateValidator.Options
@@ -141,12 +137,11 @@ public partial class RepoStateValidatorTests : IDisposable
             .Message.ShouldContain(".tools/SKILL.md");
     }
 
-    [Fact]
+    [WindowsOnlyFact]
     public void ShouldWarnWithCorrectCountForMultipleIgnoredToolSymlinks()
     {
-        RequireWindows();
-        ReplaceTrackedFileWithSymlinkOrSkip(Path.Join(".claude", "SKILL.md"));
-        ReplaceTrackedFileWithSymlinkOrSkip(Path.Join(".cursor", "AGENTS.md"));
+        ReplaceTrackedFileWithSymlink(Path.Join(".claude", "SKILL.md"));
+        ReplaceTrackedFileWithSymlink(Path.Join(".cursor", "AGENTS.md"));
 
         var sut = new RepoStateValidator();
         var options = new IRepoStateValidator.Options
@@ -164,11 +159,10 @@ public partial class RepoStateValidatorTests : IDisposable
         _testPlatformAbstractions.Messages.ShouldContain("  * .cursor/AGENTS.md");
     }
 
-    [Fact]
+    [WindowsOnlyFact]
     public void ShouldNotListIgnoredToolSymlinksWhenOutputIsSilent()
     {
-        RequireWindows();
-        ReplaceTrackedFileWithSymlinkOrSkip(Path.Join(".claude", "SKILL.md"));
+        ReplaceTrackedFileWithSymlink(Path.Join(".claude", "SKILL.md"));
 
         var previousVerbosity = CommandLineUI.Verbosity;
         try
@@ -194,11 +188,9 @@ public partial class RepoStateValidatorTests : IDisposable
         }
     }
 
-    [Fact]
+    [WindowsOnlyFact]
     public void ShouldDetectRealWindowsSymlinkInTestSymLinkFolder()
     {
-        RequireWindows();
-
         var testSymLinkDirectory = Path.Join(_testSetup.WorkingDirectory, "testSymLink");
         var claudeDirectory = Path.Join(testSymLinkDirectory, ".claude");
         var agentDirectory = Path.Join(testSymLinkDirectory, ".agent");
@@ -217,11 +209,9 @@ public partial class RepoStateValidatorTests : IDisposable
         RepoStateValidator.IsWindowsReparsePoint(realFilePath).ShouldBeFalse();
     }
 
-    [Fact]
+    [WindowsOnlyFact]
     public void ShouldRecognizeExistingDeletedFromWorkdirEntryInToolDirectoryAsIgnorable()
     {
-        RequireWindows();
-
         var testSymLinkDirectory = Path.Join(_testSetup.WorkingDirectory, "testSymLink");
         var agentDirectory = Path.Join(testSymLinkDirectory, ".agent");
         Directory.CreateDirectory(agentDirectory);
@@ -385,7 +375,7 @@ public partial class RepoStateValidatorTests : IDisposable
         _testSetup.Dispose();
     }
 
-    private void ReplaceTrackedFileWithSymlinkOrSkip(string relativePath)
+    private void ReplaceTrackedFileWithSymlink(string relativePath)
     {
         var fullPath = Path.Join(_testSetup.WorkingDirectory, relativePath);
         var directory = Path.GetDirectoryName(fullPath);
@@ -426,34 +416,16 @@ public partial class RepoStateValidatorTests : IDisposable
         }
         catch (UnauthorizedAccessException ex)
         {
-            throw Skip(ex);
+            throw new InvalidOperationException("Windows symbolic links are not available in the current test environment.", ex);
         }
         catch (IOException ex)
         {
-            throw Skip(ex);
+            throw new InvalidOperationException("Windows symbolic links are not available in the current test environment.", ex);
         }
         catch (PlatformNotSupportedException ex)
         {
-            throw Skip(ex);
+            throw new InvalidOperationException("Windows symbolic links are not available in the current test environment.", ex);
         }
-    }
-
-    private static void RequireWindows()
-    {
-        if (!OperatingSystem.IsWindows())
-        {
-            throw SkipException.ForSkip("Windows-only test.");
-        }
-    }
-
-    private static SkipException Skip()
-    {
-        return SkipException.ForSkip("Windows symbolic links are not available in the current test environment.");
-    }
-
-    private static SkipException Skip(Exception ex)
-    {
-        return SkipException.ForSkip($"Windows symbolic links are not available in the current test environment. {ex.GetType().Name}: {ex.Message}");
     }
 
 }

--- a/Versionize.Tests/Git/RepoStateValidatorTests.cs
+++ b/Versionize.Tests/Git/RepoStateValidatorTests.cs
@@ -170,20 +170,28 @@ public partial class RepoStateValidatorTests : IDisposable
         RequireWindows();
         ReplaceTrackedFileWithSymlinkOrSkip(Path.Join(".claude", "SKILL.md"));
 
-        CommandLineUI.Verbosity = Versionize.CommandLine.LogLevel.Silent;
-
-        var sut = new RepoStateValidator();
-        var options = new IRepoStateValidator.Options
+        var previousVerbosity = CommandLineUI.Verbosity;
+        try
         {
-            WorkingDirectory = _testSetup.WorkingDirectory,
-            SkipCommit = false,
-            SkipTag = false,
-            SkipDirty = false,
-            DryRun = false
-        };
+            CommandLineUI.Verbosity = Versionize.CommandLine.LogLevel.Silent;
 
-        Should.NotThrow(() => sut.Validate(_testSetup.Repository, options));
-        _testPlatformAbstractions.Messages.ShouldBeEmpty();
+            var sut = new RepoStateValidator();
+            var options = new IRepoStateValidator.Options
+            {
+                WorkingDirectory = _testSetup.WorkingDirectory,
+                SkipCommit = false,
+                SkipTag = false,
+                SkipDirty = false,
+                DryRun = false
+            };
+
+            Should.NotThrow(() => sut.Validate(_testSetup.Repository, options));
+            _testPlatformAbstractions.Messages.ShouldBeEmpty();
+        }
+        finally
+        {
+            CommandLineUI.Verbosity = previousVerbosity;
+        }
     }
 
     [Fact]

--- a/Versionize.Tests/TestSupport/WindowsOnlyFactAttribute.cs
+++ b/Versionize.Tests/TestSupport/WindowsOnlyFactAttribute.cs
@@ -1,0 +1,25 @@
+using Xunit;
+
+namespace Versionize.Tests.TestSupport;
+
+public sealed class WindowsOnlyFactAttribute : FactAttribute
+{
+    public WindowsOnlyFactAttribute()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Skip = "Windows-only test.";
+        }
+    }
+}
+
+public sealed class WindowsOnlyTheoryAttribute : TheoryAttribute
+{
+    public WindowsOnlyTheoryAttribute()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Skip = "Windows-only test.";
+        }
+    }
+}

--- a/Versionize/CommandLine/CommandLineUI.cs
+++ b/Versionize/CommandLine/CommandLineUI.cs
@@ -28,7 +28,7 @@ public static class CommandLineUI
 
     public static void Warning(string message)
     {
-        if (Verbosity < LogLevel.Error)
+        if (Verbosity < LogLevel.All)
         {
             return;
         }

--- a/Versionize/CommandLine/CommandLineUI.cs
+++ b/Versionize/CommandLine/CommandLineUI.cs
@@ -26,6 +26,16 @@ public static class CommandLineUI
         Platform.WriteLine(message, ConsoleColor.Gray);
     }
 
+    public static void Warning(string message)
+    {
+        if (Verbosity < LogLevel.Error)
+        {
+            return;
+        }
+
+        Platform.WriteLine(message, ConsoleColor.Yellow);
+    }
+
     public static void Step(string message)
     {
         if (Verbosity < LogLevel.All)

--- a/Versionize/CommandLine/InfoMessages.cs
+++ b/Versionize/CommandLine/InfoMessages.cs
@@ -14,5 +14,5 @@ public static class InfoMessages
     public static string IgnoredToolSymlinks(int count, string toolDirectoryList) =>
         $"Warning: Detected {count} symlink{(count == 1 ? "" : "s")} in tool directories ({toolDirectoryList}). Please verify them manually.";
     public static string IgnoredToolDirectoryEntries(int count, string toolDirectoryList) =>
-        $"Warning: Detected {count} tool-managed entr{(count == 1 ? "y" : "ies")} in ({toolDirectoryList}) reported as deleted although they still exist on disk. Please verify them manually.";
+        $"Warning: Detected {count} tool-managed entr{(count == 1 ? "y" : "ies")} in tool directories ({toolDirectoryList}) that were reported as deleted but still exist on disk. Please verify them manually.";
 }

--- a/Versionize/CommandLine/InfoMessages.cs
+++ b/Versionize/CommandLine/InfoMessages.cs
@@ -5,10 +5,16 @@ namespace Versionize.CommandLine;
 /// </summary>
 public static class InfoMessages
 {
+    public const string ToolDirectoryList = ".claude, .agent, .agents, .cursor, .winsurf, .windsurf, .opencode, .codex";
+
     public static string DiscoveredVersionableProjects(int count) => $"Discovered {count} versionable projects";
     public static string ProjectFile(string path) => $"  * {path}";
     public static string UpdatedChangelog(string? file = "CHANGELOG.md") => $"updated {file}";
     public static string CommittedChanges(string changelogFile) => $"committed changes in projects and {changelogFile}";
     public static string BumpingVersion(string from, string to) => $"bumping version from {from} to {to} in projects";
     public static string TaggedRelease(string tagName, string sha) => $"tagged release as {tagName} against commit with sha {sha}";
+    public static string IgnoredToolSymlinks(int count) =>
+        $"Warning: Detected {count} symlink{(count == 1 ? "" : "s")} in tool directories ({ToolDirectoryList}). Please verify them manually.";
+    public static string IgnoredToolDirectoryEntries(int count) =>
+        $"Warning: Detected {count} tool-managed entr{(count == 1 ? "y" : "ies")} in ({ToolDirectoryList}) reported as deleted although they still exist on disk. Please verify them manually.";
 }

--- a/Versionize/CommandLine/InfoMessages.cs
+++ b/Versionize/CommandLine/InfoMessages.cs
@@ -5,16 +5,14 @@ namespace Versionize.CommandLine;
 /// </summary>
 public static class InfoMessages
 {
-    public const string ToolDirectoryList = ".claude, .agent, .agents, .cursor, .winsurf, .windsurf, .opencode, .codex";
-
     public static string DiscoveredVersionableProjects(int count) => $"Discovered {count} versionable projects";
     public static string ProjectFile(string path) => $"  * {path}";
     public static string UpdatedChangelog(string? file = "CHANGELOG.md") => $"updated {file}";
     public static string CommittedChanges(string changelogFile) => $"committed changes in projects and {changelogFile}";
     public static string BumpingVersion(string from, string to) => $"bumping version from {from} to {to} in projects";
     public static string TaggedRelease(string tagName, string sha) => $"tagged release as {tagName} against commit with sha {sha}";
-    public static string IgnoredToolSymlinks(int count) =>
-        $"Warning: Detected {count} symlink{(count == 1 ? "" : "s")} in tool directories ({ToolDirectoryList}). Please verify them manually.";
-    public static string IgnoredToolDirectoryEntries(int count) =>
-        $"Warning: Detected {count} tool-managed entr{(count == 1 ? "y" : "ies")} in ({ToolDirectoryList}) reported as deleted although they still exist on disk. Please verify them manually.";
+    public static string IgnoredToolSymlinks(int count, string toolDirectoryList) =>
+        $"Warning: Detected {count} symlink{(count == 1 ? "" : "s")} in tool directories ({toolDirectoryList}). Please verify them manually.";
+    public static string IgnoredToolDirectoryEntries(int count, string toolDirectoryList) =>
+        $"Warning: Detected {count} tool-managed entr{(count == 1 ? "y" : "ies")} in ({toolDirectoryList}) reported as deleted although they still exist on disk. Please verify them manually.";
 }

--- a/Versionize/Git/RepoStateValidator.cs
+++ b/Versionize/Git/RepoStateValidator.cs
@@ -32,7 +32,7 @@ internal interface IRepoStateValidator
 
 internal class RepoStateValidator : IRepoStateValidator
 {
-    private static readonly string[] IgnoredToolDirectories =
+    internal static readonly string[] IgnoredToolDirectories =
     [
         ".claude",
         ".agent",
@@ -43,6 +43,8 @@ internal class RepoStateValidator : IRepoStateValidator
         ".opencode",
         ".codex"
     ];
+
+    internal static string IgnoredToolDirectoryList => string.Join(", ", IgnoredToolDirectories);
 
     /// <summary>
     /// Ensures<br/>
@@ -84,7 +86,7 @@ internal class RepoStateValidator : IRepoStateValidator
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         var dirtyFiles = status
-            .Where(x => x.State != FileStatus.Ignored && !ignoredPaths.Contains(x.FilePath))
+            .Where(x => !HasState(x.State, FileStatus.Ignored) && !ignoredPaths.Contains(x.FilePath))
             .Select(x => $"{x.State}: {x.FilePath}")
             .ToList();
 
@@ -117,18 +119,18 @@ internal class RepoStateValidator : IRepoStateValidator
 
     internal static bool IsIgnoredToolSymlink(string filePath, FileStatus state, string repositoryRoot)
     {
-        if (state == FileStatus.Ignored || !OperatingSystem.IsWindows())
+        if (HasState(state, FileStatus.Ignored) || !OperatingSystem.IsWindows())
         {
             return false;
         }
 
         var fullPath = Path.GetFullPath(Path.Combine(repositoryRoot, filePath));
-        return IsToolDirectoryPath(fullPath, repositoryRoot) && IsWindowsSymlink(fullPath);
+        return IsToolDirectoryPath(fullPath, repositoryRoot) && IsWindowsReparsePoint(fullPath);
     }
 
     internal static bool IsIgnoredExistingToolEntry(string filePath, FileStatus state, string repositoryRoot)
     {
-        if (state != FileStatus.DeletedFromWorkdir || !OperatingSystem.IsWindows())
+        if (!HasState(state, FileStatus.DeletedFromWorkdir) || !OperatingSystem.IsWindows())
         {
             return false;
         }
@@ -147,7 +149,7 @@ internal class RepoStateValidator : IRepoStateValidator
         });
     }
 
-    internal static bool IsWindowsSymlink(string fullPath)
+    internal static bool IsWindowsReparsePoint(string fullPath)
     {
         if (!File.Exists(fullPath) && !Directory.Exists(fullPath))
         {
@@ -160,6 +162,11 @@ internal class RepoStateValidator : IRepoStateValidator
     internal static bool PathExists(string fullPath)
     {
         return File.Exists(fullPath) || Directory.Exists(fullPath);
+    }
+
+    private static bool HasState(FileStatus state, FileStatus expected)
+    {
+        return (state & expected) == expected;
     }
 
     private static string EnsureTrailingSeparator(string path)
@@ -176,7 +183,7 @@ internal class RepoStateValidator : IRepoStateValidator
             return;
         }
 
-        CommandLineUI.Warning(InfoMessages.IgnoredToolSymlinks(ignoredSymlinks.Count));
+        CommandLineUI.Warning(InfoMessages.IgnoredToolSymlinks(ignoredSymlinks.Count, IgnoredToolDirectoryList));
 
         if (CommandLineUI.Verbosity < Versionize.CommandLine.LogLevel.All)
         {
@@ -196,7 +203,7 @@ internal class RepoStateValidator : IRepoStateValidator
             return;
         }
 
-        CommandLineUI.Warning(InfoMessages.IgnoredToolDirectoryEntries(ignoredExistingToolEntries.Count));
+        CommandLineUI.Warning(InfoMessages.IgnoredToolDirectoryEntries(ignoredExistingToolEntries.Count, IgnoredToolDirectoryList));
 
         if (CommandLineUI.Verbosity < Versionize.CommandLine.LogLevel.All)
         {

--- a/Versionize/Git/RepoStateValidator.cs
+++ b/Versionize/Git/RepoStateValidator.cs
@@ -151,12 +151,32 @@ internal class RepoStateValidator : IRepoStateValidator
 
     internal static bool IsWindowsReparsePoint(string fullPath)
     {
-        if (!File.Exists(fullPath) && !Directory.Exists(fullPath))
+        if (!OperatingSystem.IsWindows())
         {
             return false;
         }
 
-        return File.GetAttributes(fullPath).HasFlag(FileAttributes.ReparsePoint);
+        try
+        {
+            var attributes = File.GetAttributes(fullPath);
+            return attributes.HasFlag(FileAttributes.ReparsePoint);
+        }
+        catch (FileNotFoundException)
+        {
+            return false;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
     }
 
     internal static bool PathExists(string fullPath)

--- a/Versionize/Git/RepoStateValidator.cs
+++ b/Versionize/Git/RepoStateValidator.cs
@@ -32,6 +32,18 @@ internal interface IRepoStateValidator
 
 internal class RepoStateValidator : IRepoStateValidator
 {
+    private static readonly string[] IgnoredToolDirectories =
+    [
+        ".claude",
+        ".agent",
+        ".agents",
+        ".cursor",
+        ".winsurf",
+        ".windsurf",
+        ".opencode",
+        ".codex"
+    ];
+
     /// <summary>
     /// Ensures<br/>
     /// - Git user config is set for commit/tag write operations.<br/>
@@ -53,9 +65,31 @@ internal class RepoStateValidator : IRepoStateValidator
         }
 
         var status = repository.RetrieveStatus(new StatusOptions { IncludeUntracked = false });
-        if (status.IsDirty && !options.SkipDirty)
+        var repositoryRoot = Path.GetFullPath(repository.Info.WorkingDirectory);
+
+        var ignoredSymlinks = status
+            .Where(entry => IsIgnoredToolSymlink(entry.FilePath, entry.State, repositoryRoot))
+            .ToList();
+
+        var ignoredExistingToolEntries = status
+            .Where(entry => IsIgnoredExistingToolEntry(entry.FilePath, entry.State, repositoryRoot))
+            .ToList();
+
+        WarnAboutIgnoredSymlinks(ignoredSymlinks);
+        WarnAboutIgnoredExistingToolEntries(ignoredExistingToolEntries);
+
+        var ignoredPaths = ignoredSymlinks
+            .Concat(ignoredExistingToolEntries)
+            .Select(x => x.FilePath)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var dirtyFiles = status
+            .Where(x => x.State != FileStatus.Ignored && !ignoredPaths.Contains(x.FilePath))
+            .Select(x => $"{x.State}: {x.FilePath}")
+            .ToList();
+
+        if (dirtyFiles.Count != 0 && !options.SkipDirty)
         {
-            var dirtyFiles = status.Where(x => x.State != FileStatus.Ignored).Select(x => $"{x.State}: {x.FilePath}");
             var dirtyFilesString = string.Join(Environment.NewLine, dirtyFiles);
             throw new VersionizeException(ErrorMessages.RepositoryDirty(options.WorkingDirectory, dirtyFilesString), 1);
         }
@@ -79,5 +113,99 @@ internal class RepoStateValidator : IRepoStateValidator
         var email = repository.Config.Get<string>("user.email");
 
         return name != null && email != null;
+    }
+
+    internal static bool IsIgnoredToolSymlink(string filePath, FileStatus state, string repositoryRoot)
+    {
+        if (state == FileStatus.Ignored || !OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+
+        var fullPath = Path.GetFullPath(Path.Combine(repositoryRoot, filePath));
+        return IsToolDirectoryPath(fullPath, repositoryRoot) && IsWindowsSymlink(fullPath);
+    }
+
+    internal static bool IsIgnoredExistingToolEntry(string filePath, FileStatus state, string repositoryRoot)
+    {
+        if (state != FileStatus.DeletedFromWorkdir || !OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+
+        var fullPath = Path.GetFullPath(Path.Combine(repositoryRoot, filePath));
+        return IsToolDirectoryPath(fullPath, repositoryRoot) && PathExists(fullPath);
+    }
+
+    internal static bool IsToolDirectoryPath(string fullPath, string repositoryRoot)
+    {
+        return IgnoredToolDirectories.Any(directory =>
+        {
+            var toolRoot = Path.Combine(repositoryRoot, directory);
+            var normalizedToolRoot = EnsureTrailingSeparator(Path.GetFullPath(toolRoot));
+            return fullPath.StartsWith(normalizedToolRoot, StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    internal static bool IsWindowsSymlink(string fullPath)
+    {
+        if (!File.Exists(fullPath) && !Directory.Exists(fullPath))
+        {
+            return false;
+        }
+
+        return File.GetAttributes(fullPath).HasFlag(FileAttributes.ReparsePoint);
+    }
+
+    internal static bool PathExists(string fullPath)
+    {
+        return File.Exists(fullPath) || Directory.Exists(fullPath);
+    }
+
+    private static string EnsureTrailingSeparator(string path)
+    {
+        return path.EndsWith(Path.DirectorySeparatorChar) || path.EndsWith(Path.AltDirectorySeparatorChar)
+            ? path
+            : path + Path.DirectorySeparatorChar;
+    }
+
+    private static void WarnAboutIgnoredSymlinks(IReadOnlyCollection<StatusEntry> ignoredSymlinks)
+    {
+        if (ignoredSymlinks.Count == 0)
+        {
+            return;
+        }
+
+        CommandLineUI.Warning(InfoMessages.IgnoredToolSymlinks(ignoredSymlinks.Count));
+
+        if (CommandLineUI.Verbosity < Versionize.CommandLine.LogLevel.All)
+        {
+            return;
+        }
+
+        foreach (var ignoredSymlink in ignoredSymlinks.OrderBy(x => x.FilePath, StringComparer.OrdinalIgnoreCase))
+        {
+            CommandLineUI.Information(InfoMessages.ProjectFile(ignoredSymlink.FilePath));
+        }
+    }
+
+    private static void WarnAboutIgnoredExistingToolEntries(IReadOnlyCollection<StatusEntry> ignoredExistingToolEntries)
+    {
+        if (ignoredExistingToolEntries.Count == 0)
+        {
+            return;
+        }
+
+        CommandLineUI.Warning(InfoMessages.IgnoredToolDirectoryEntries(ignoredExistingToolEntries.Count));
+
+        if (CommandLineUI.Verbosity < Versionize.CommandLine.LogLevel.All)
+        {
+            return;
+        }
+
+        foreach (var ignoredEntry in ignoredExistingToolEntries.OrderBy(x => x.FilePath, StringComparer.OrdinalIgnoreCase))
+        {
+            CommandLineUI.Information(InfoMessages.ProjectFile(ignoredEntry.FilePath));
+        }
     }
 }


### PR DESCRIPTION
# Fix Windows tool-managed entries in repository dirty check

## Summary
This PR updates the repository dirty-state validation to better handle Windows-specific tool-managed files inside agent directories such as `.claude`, `.agent`, `.agents`, `.cursor`, `.winsurf`, `.windsurf`, `.opencode`, and `.codex`.

With the growing use of AI skills, local tooling may install shared skill content into these directories. Tools such as `skills` from `skills.sh` can create symlinks instead of duplicating files. On Windows, LibGit2Sharp may report these entries as dirty even though they are tool-managed and should not block `versionize`. The validator now ignores:

- real Windows symlinks inside the supported tool directories
- `DeletedFromWorkdir` entries in those directories when the file still exists on disk

The command still warns the user when such entries are detected and continues to fail for actual dirty files outside the supported cases.

## Motivation
`versionize` could incorrectly stop before execution on Windows when AI skill tooling installed shared files into agent directories using symlinks or similar file-system behavior. In practice, this forced users to fall back to `--skip-dirty`, even though bypassing the dirty check should not be the default path for normal usage.

In real repositories, Git CLI could report a clean working tree while LibGit2Sharp still surfaced false-positive dirty entries for those tool-managed paths. This change aligns validation with that real-world scenario without weakening normal dirty-repository protection.

## Changes
- added warning output support to the command-line UI
- extended repo state validation with Windows-specific filtering for supported tool directories
- added warning messages for ignored symlinks and existing-on-disk deleted entries
- added focused validator tests for:
  - supported tool-directory symlinks
  - mixed ignored entries plus real dirty files
  - unsupported directories remaining dirty
  - silent output behavior
  - real Windows symlink detection using a `testSymLink` folder
  - `DeletedFromWorkdir` entries that still exist on disk

## Testing
- `dotnet test Versionize.Tests/Versionize.Tests.csproj`
- `dotnet "D:\git\versionize\Versionize\bin\Debug\net10.0\Versionize.dll" --workingDir "D:\git\#wgtApp\WgtApp.Management" --dry-run`

## Notes
- The dry run now succeeds for the tested Windows repository and reports ignored tool-managed entries as warnings instead of blocking execution.
- Normal dirty-file handling remains unchanged for non-tool paths and real repository changes.
