### PR TITLE
docs(readme): fix header patterns slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ To configure custom header patterns, create a `.versionize` file in your working
 {
   "CommitParser": {
     "HeaderPatterns": [
-      "^Merged PR \\\\d+: (?<type>\\w*)(?:\\((?<scope>.*)\\))?(?<breakingChangeMarker>!)?: (?<subject>.*)$",
-      "^Pull Request \\\\d+: (?<type>\\w*)(?:\\((?<scope>.*)\\))?(?<breakingChangeMarker>!)?: (?<subject>.*)$"
+      "^Merged PR \\d+: (?<type>\\w*)(?:\\((?<scope>.*)\\))?(?<breakingChangeMarker>!)?: (?<subject>.*)$",
+      "^Pull Request \\d+: (?<type>\\w*)(?:\\((?<scope>.*)\\))?(?<breakingChangeMarker>!)?: (?<subject>.*)$"
     ]
   }
 }


### PR DESCRIPTION
Hello, thank you for this tool; it works well.
While I was testing it, I noticed that my commits with "Merged PR" did not work. After investigating, I found that the issue was with the regex provided in the README.md.

Before : 
<img width="833" height="229" alt="image" src="https://github.com/user-attachments/assets/2b89dcd0-4e30-4df9-9bb4-c6fbc2da6a89" />

After : 
<img width="1001" height="200" alt="image" src="https://github.com/user-attachments/assets/07d967e8-746b-4c80-b75a-1551766caa65" />
